### PR TITLE
✨ feat(hierarchy): add hierarchy-aware role casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ capabilities:
   - web-read
   - bash:
       - "npx repomix@latest*"
+
+level: L3
+class: leaf
+callable: true
+scheduled: false
+max_delegate_depth: 0
 ---
 
 # Explorer
@@ -89,6 +95,9 @@ agent-caster 从源仓库中查找 agent 定义：
 
 1. 有 `refit.toml` 且指定 `agents_dir` → 使用该路径
 2. 否则 → 默认 `roles/*.md`
+
+`roles.toml` 的 target 现在也支持 `output_layout = "preserve" | "namespace" | "flatten"`，
+可用于保留嵌套 `roles/` 的路径语义或显式启用扁平化输出。
 
 ## Supported Tools
 

--- a/src/agent_caster/adapters/claude.py
+++ b/src/agent_caster/adapters/claude.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 from agent_caster.groups import BASH_POLICIES, TOOL_GROUPS
 from agent_caster.models import AgentDef, BaseAdapter, ModelConfig, OutputFile, TargetConfig
+from agent_caster.topology import build_output_path, validate_agents, validate_output_layout
 
 # Semantic tool id -> Claude Code tool name
 _TOOL_NAME_MAP: dict[str, str] = {
@@ -33,10 +34,17 @@ class ClaudeAdapter(BaseAdapter):
         agents: list[AgentDef],
         config: TargetConfig,
     ) -> list[OutputFile]:
+        delegation_graph = validate_agents(agents)
+        validate_output_layout(agents, config)
+
         outputs = []
         for agent in agents:
-            content = self._generate_agent_md(agent, config)
-            path = f".claude/agents/{agent.name}.md"
+            delegates = [
+                target.output_id(config.output_layout)
+                for target in delegation_graph.get(agent.canonical_id, [])
+            ]
+            content = self._generate_agent_md(agent, config, delegates)
+            path = build_output_path(agent, base_dir=".claude/agents", suffix=".md", config=config)
             outputs.append(OutputFile(path=path, content=content))
         return outputs
 
@@ -136,8 +144,10 @@ class ClaudeAdapter(BaseAdapter):
         lines.append("---")
         return "\n".join(lines)
 
-    def _generate_agent_md(self, agent: AgentDef, config: TargetConfig) -> str:
-        tools, bash_patterns, delegates = self._expand_capabilities(
+    def _generate_agent_md(
+        self, agent: AgentDef, config: TargetConfig, delegates: list[str]
+    ) -> str:
+        tools, bash_patterns, _ = self._expand_capabilities(
             agent.capabilities, config.capability_map
         )
 

--- a/src/agent_caster/adapters/cursor.py
+++ b/src/agent_caster/adapters/cursor.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import ClassVar
 
 from agent_caster.models import AgentDef, BaseAdapter, OutputFile, TargetConfig
+from agent_caster.topology import build_output_path, validate_agents, validate_output_layout
 
 
 class CursorAdapter(BaseAdapter):
@@ -37,10 +38,13 @@ class CursorAdapter(BaseAdapter):
         agents: list[AgentDef],
         config: TargetConfig,
     ) -> list[OutputFile]:
+        validate_agents(agents)
+        validate_output_layout(agents, config)
+
         outputs = []
         for agent in agents:
             content = self._generate_agent_mdc(agent)
-            path = f".cursor/agents/{agent.name}.mdc"
+            path = build_output_path(agent, base_dir=".cursor/agents", suffix=".mdc", config=config)
             outputs.append(OutputFile(path=path, content=content))
         return outputs
 

--- a/src/agent_caster/adapters/opencode.py
+++ b/src/agent_caster/adapters/opencode.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from agent_caster.groups import BASH_POLICIES, TOOL_GROUPS
 from agent_caster.models import AgentDef, BaseAdapter, ModelConfig, OutputFile, TargetConfig
+from agent_caster.topology import build_output_path, validate_agents, validate_output_layout
 
 
 class OpenCodeAdapter(BaseAdapter):
@@ -17,10 +18,19 @@ class OpenCodeAdapter(BaseAdapter):
         agents: list[AgentDef],
         config: TargetConfig,
     ) -> list[OutputFile]:
+        delegation_graph = validate_agents(agents)
+        validate_output_layout(agents, config)
+
         outputs = []
         for agent in agents:
-            content = self._generate_agent_md(agent, config)
-            path = f".opencode/agents/{agent.name}.md"
+            delegates = [
+                target.output_id(config.output_layout)
+                for target in delegation_graph.get(agent.canonical_id, [])
+            ]
+            content = self._generate_agent_md(agent, config, delegates)
+            path = build_output_path(
+                agent, base_dir=".opencode/agents", suffix=".md", config=config
+            )
             outputs.append(OutputFile(path=path, content=content))
         return outputs
 
@@ -151,8 +161,10 @@ class OpenCodeAdapter(BaseAdapter):
         lines.append("---")
         return "\n".join(lines)
 
-    def _generate_agent_md(self, agent: AgentDef, config: TargetConfig) -> str:
-        tools, bash_allowed, delegates = self._expand_capabilities(
+    def _generate_agent_md(
+        self, agent: AgentDef, config: TargetConfig, delegates: list[str]
+    ) -> str:
+        tools, bash_allowed, _ = self._expand_capabilities(
             agent.capabilities, config.capability_map
         )
 

--- a/src/agent_caster/adapters/windsurf.py
+++ b/src/agent_caster/adapters/windsurf.py
@@ -35,6 +35,7 @@ Notes:
 from __future__ import annotations
 
 from agent_caster.models import AgentDef, BaseAdapter, OutputFile, TargetConfig
+from agent_caster.topology import build_output_path, validate_agents, validate_output_layout
 
 TRIGGER = "model_decision"
 
@@ -47,10 +48,13 @@ class WindsurfAdapter(BaseAdapter):
         agents: list[AgentDef],
         config: TargetConfig,
     ) -> list[OutputFile]:
+        validate_agents(agents)
+        validate_output_layout(agents, config)
+
         outputs = []
         for agent in agents:
             content = self._generate_rule(agent)
-            path = f".windsurf/rules/{agent.name}.md"
+            path = build_output_path(agent, base_dir=".windsurf/rules", suffix=".md", config=config)
             outputs.append(OutputFile(path=path, content=content))
         return outputs
 

--- a/src/agent_caster/cli.py
+++ b/src/agent_caster/cli.py
@@ -78,6 +78,32 @@ def _resolve_target_config(
     raise typer.Exit(1)
 
 
+def _write_outputs(project: Path, outputs, output_dir: str) -> None:
+    """Write cast outputs beneath the configured output_dir."""
+    for out in outputs:
+        full_path = (project / output_dir / out.path).resolve()
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(out.content, encoding="utf-8")
+
+
+def _resolve_remove_target(agents, ref: str):
+    """Resolve a remove reference by canonical id first, then by unique name."""
+    by_id = {agent.canonical_id: agent for agent in agents}
+    if ref in by_id:
+        return by_id[ref]
+
+    matches = [agent for agent in agents if agent.name == ref]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        choices = ", ".join(agent.canonical_id for agent in matches)
+        logger.error(f"Ambiguous agent name '{ref}'. Use one of: {choices}")
+        raise typer.Exit(1)
+
+    logger.error(f"Agent not found: {ref}")
+    raise typer.Exit(1)
+
+
 @app.command()
 def add(
     source: Annotated[str, typer.Argument(help="Source: org/repo[@ref] or local path")],
@@ -97,6 +123,7 @@ def add(
     from agent_caster.loader import load_agents
     from agent_caster.platform import detect_platforms
     from agent_caster.registry import fetch_source, find_agents_dir, parse_source
+    from agent_caster.topology import TopologyError, validate_agents
 
     parsed = parse_source(source)
 
@@ -116,10 +143,15 @@ def add(
     if not agents:
         logger.error("No agent definitions found in source.")
         raise typer.Exit(1)
+    try:
+        validate_agents(agents)
+    except TopologyError as e:
+        logger.error(str(e))
+        raise typer.Exit(1) from e
 
     logger.info(f"Found {len(agents)} agents:")
     for a in agents:
-        logger.info(f"  {a.name:<25} {a.role:<10} {a.model.tier}")
+        logger.info(f"  {a.canonical_id:<25} {a.role:<10} {a.model.tier}")
 
     # Determine install target
     if global_install:
@@ -133,9 +165,10 @@ def add(
     # Copy agent files
     for a in agents:
         if a.source_path:
-            dest = install_dir / a.source_path.name
+            dest = install_dir / a.install_relative_path()
+            dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(a.source_path, dest)
-            logger.info(f"  Installed {a.name}")
+            logger.info(f"  Installed {a.canonical_id}")
 
     logger.info(f"\nInstalled {len(agents)} agents to {install_dir}")
 
@@ -160,11 +193,12 @@ def add(
 
         config = _resolve_target_config(target_name, adapter, project)
 
-        outputs = adapter.cast(installed_agents, config)
-        for out in outputs:
-            full_path = project / out.path
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_text(out.content, encoding="utf-8")
+        try:
+            outputs = adapter.cast(installed_agents, config)
+        except TopologyError as e:
+            logger.error(str(e))
+            raise typer.Exit(1) from e
+        _write_outputs(project, outputs, config.output_dir)
 
         logger.info(f"Cast {len(outputs)} agents → {target_name}")
 
@@ -187,11 +221,14 @@ def list_agents(
 
     agents = load_agents(agents_dir)
 
-    logger.info(f"{'AGENT':<25} {'ROLE':<10} {'TIER':<12} {'TEMP':<6}")
-    logger.info("-" * 55)
+    logger.info(f"{'AGENT':<25} {'ID':<25} {'ROLE':<10} {'TIER':<12} {'TEMP':<6}")
+    logger.info("-" * 82)
     for agent in agents:
         temp = str(agent.model.temperature) if agent.model.temperature is not None else "-"
-        logger.info(f"{agent.name:<25} {agent.role:<10} {agent.model.tier:<12} {temp:<6}")
+        logger.info(
+            f"{agent.name:<25} {agent.canonical_id:<25} {agent.role:<10} "
+            f"{agent.model.tier:<12} {temp:<6}"
+        )
 
     logger.info(f"\n{len(agents)} agents found")
 
@@ -209,6 +246,7 @@ def cast(
     from agent_caster.adapters import get_adapter
     from agent_caster.loader import load_agents
     from agent_caster.platform import detect_platforms
+    from agent_caster.topology import TopologyError, validate_agents
 
     project = Path(project_dir).resolve() if project_dir else Path.cwd()
     agents_dir = project / ".agents" / "roles"
@@ -218,6 +256,11 @@ def cast(
         raise typer.Exit(1)
 
     agents = load_agents(agents_dir)
+    try:
+        validate_agents(agents)
+    except TopologyError as e:
+        logger.error(str(e))
+        raise typer.Exit(1) from e
     cast_targets = list(target) if target else detect_platforms(project)
 
     if not cast_targets:
@@ -233,34 +276,37 @@ def cast(
 
         config = _resolve_target_config(target_name, adapter, project)
 
-        outputs = adapter.cast(agents, config)
-        for out in outputs:
-            full_path = project / out.path
-            full_path.parent.mkdir(parents=True, exist_ok=True)
-            full_path.write_text(out.content, encoding="utf-8")
+        try:
+            outputs = adapter.cast(agents, config)
+        except TopologyError as e:
+            logger.error(str(e))
+            raise typer.Exit(1) from e
+        _write_outputs(project, outputs, config.output_dir)
 
         logger.info(f"Cast {len(outputs)} agents → {target_name}")
 
 
 @app.command()
 def remove(
-    agent_name: Annotated[str, typer.Argument(help="Agent name to remove")],
+    agent_name: Annotated[str, typer.Argument(help="Agent canonical id or unique name to remove")],
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
     project_dir: Annotated[
         str | None, typer.Option("--project-dir", help="Project root directory")
     ] = None,
 ) -> None:
     """Remove an installed agent definition."""
+    from agent_caster.loader import load_agents
+
     project = Path(project_dir).resolve() if project_dir else Path.cwd()
     agents_dir = project / ".agents" / "roles"
-    agent_file = agents_dir / f"{agent_name}.md"
-
-    if not agent_file.is_file():
-        logger.error(f"Agent not found: {agent_name}")
+    if not agents_dir.is_dir():
+        logger.error("No agents found. Run 'agent-caster add' first.")
         raise typer.Exit(1)
 
+    agent = _resolve_remove_target(load_agents(agents_dir), agent_name)
+    agent_file = agents_dir / agent.install_relative_path()
     agent_file.unlink()
-    logger.info(f"Removed {agent_name}")
+    logger.info(f"Removed {agent.canonical_id}")
     logger.info(
         "Note: platform-specific files may still exist. Run 'agent-caster cast' to regenerate."
     )

--- a/src/agent_caster/config.py
+++ b/src/agent_caster/config.py
@@ -62,6 +62,7 @@ def _parse_target(name: str, raw: dict) -> TargetConfig:
         name=name,
         enabled=raw.get("enabled", True),
         output_dir=raw.get("output_dir", "."),
+        output_layout=raw.get("output_layout", "preserve"),
         model_map=raw.get("model_map", {}),
         capability_map=raw.get("capability_map", {}),
     )

--- a/src/agent_caster/loader.py
+++ b/src/agent_caster/loader.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import yaml
+from pydantic import ValidationError
 
 from agent_caster.log import logger
-from agent_caster.models import AgentDef, ModelConfig
+from agent_caster.models import AgentDef, HierarchyConfig, ModelConfig
 
 
 class LoadError(Exception):
@@ -31,7 +32,7 @@ def load_agents(agents_dir: Path, *, strict: bool = False) -> list[AgentDef]:
     for md_path in sorted(agents_dir.rglob("*.md")):
         logger.debug(f"Loading agent from {md_path.relative_to(agents_dir)}")
         try:
-            agents.append(parse_agent_file(md_path))
+            agents.append(parse_agent_file(md_path, agents_dir=agents_dir))
         except LoadError as exc:
             if strict:
                 raise
@@ -40,7 +41,7 @@ def load_agents(agents_dir: Path, *, strict: bool = False) -> list[AgentDef]:
     return agents
 
 
-def parse_agent_file(md_path: Path) -> AgentDef:
+def parse_agent_file(md_path: Path, *, agents_dir: Path | None = None) -> AgentDef:
     """Parse a single agent definition file."""
     text = md_path.read_text(encoding="utf-8")
     fm_text, body = _split_frontmatter(text)
@@ -56,20 +57,31 @@ def parse_agent_file(md_path: Path) -> AgentDef:
         tier=raw_model.get("tier", "reasoning"),
         temperature=raw_model.get("temperature"),
     )
+    hierarchy = _parse_hierarchy(defn)
 
     prompt_content = _resolve_prompt(defn, body, md_path.parent)
-
-    return AgentDef(
-        name=defn["name"],
-        description=(defn.get("description", "") or "").strip(),
-        role=defn.get("role", "subagent"),
-        model=model,
-        skills=defn.get("skills", []) or [],
-        capabilities=defn.get("capabilities", []) or [],
-        prompt_content=prompt_content,
-        prompt_file=defn.get("prompt_file"),
-        source_path=md_path.resolve(),
+    relative_path = (
+        md_path.resolve().relative_to(agents_dir.resolve()).as_posix()
+        if agents_dir is not None
+        else md_path.name
     )
+
+    try:
+        return AgentDef(
+            name=defn["name"],
+            description=(defn.get("description", "") or "").strip(),
+            role=defn.get("role", "subagent"),
+            model=model,
+            skills=defn.get("skills", []) or [],
+            capabilities=defn.get("capabilities", []) or [],
+            hierarchy=hierarchy,
+            prompt_content=prompt_content,
+            prompt_file=defn.get("prompt_file"),
+            source_path=md_path.resolve(),
+            relative_path=relative_path,
+        )
+    except ValidationError as exc:
+        raise LoadError(f"Invalid agent metadata in {md_path}: {exc}") from exc
 
 
 def _split_frontmatter(text: str) -> tuple[str, str]:
@@ -94,3 +106,27 @@ def _resolve_prompt(defn: dict, body: str, file_dir: Path) -> str:
             return prompt_path.read_text(encoding="utf-8")
         return ""
     return body
+
+
+def _parse_hierarchy(defn: dict) -> HierarchyConfig:
+    """Parse first-class hierarchy metadata from top-level or nested keys."""
+    raw_hierarchy = defn.get("hierarchy", {}) or {}
+    if raw_hierarchy and not isinstance(raw_hierarchy, dict):
+        raise LoadError("Field 'hierarchy' must be a mapping when provided")
+
+    merged = dict(raw_hierarchy)
+    for key in (
+        "level",
+        "class",
+        "scheduled",
+        "callable",
+        "max_delegate_depth",
+        "allowed_children",
+    ):
+        if key in defn:
+            merged[key] = defn[key]
+
+    try:
+        return HierarchyConfig.model_validate(merged)
+    except ValidationError as exc:
+        raise LoadError(f"Invalid hierarchy metadata: {exc}") from exc

--- a/src/agent_caster/models.py
+++ b/src/agent_caster/models.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ModelConfig(BaseModel, frozen=True):
@@ -23,6 +23,19 @@ class ModelConfig(BaseModel, frozen=True):
     temperature: float | None = None
 
 
+class HierarchyConfig(BaseModel, frozen=True):
+    """Optional first-class hierarchy metadata for a role."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    level: str | int | None = None
+    role_class: str | None = Field(default=None, alias="class")
+    scheduled: bool = False
+    callable: bool = True
+    max_delegate_depth: int | None = Field(default=None, ge=0)
+    allowed_children: list[str] = Field(default_factory=list)
+
+
 class AgentDef(BaseModel, frozen=True):
     """Parsed canonical agent definition.
 
@@ -33,11 +46,57 @@ class AgentDef(BaseModel, frozen=True):
     description: str = ""
     role: Literal["primary", "subagent"] = "subagent"
     model: ModelConfig = ModelConfig()
-    skills: list[str] = []
-    capabilities: list[str | dict[str, Any]] = []
+    skills: list[str] = Field(default_factory=list)
+    capabilities: list[str | dict[str, Any]] = Field(default_factory=list)
+    hierarchy: HierarchyConfig = Field(default_factory=HierarchyConfig)
     prompt_content: str = ""
     prompt_file: str | None = None
     source_path: Path | None = None
+    relative_path: str | None = None
+
+    @property
+    def canonical_id(self) -> str:
+        """Stable role id derived from relative source path when available."""
+        if self.relative_path:
+            return str(PurePosixPath(self.relative_path).with_suffix(""))
+        if self.source_path is not None:
+            return self.source_path.stem
+        return self.name
+
+    @property
+    def namespace(self) -> str:
+        """Directory portion of the canonical id, if any."""
+        canonical_path = PurePosixPath(self.canonical_id)
+        return (
+            canonical_path.parent.as_posix() if canonical_path.parent != PurePosixPath(".") else ""
+        )
+
+    def output_id(self, layout: Literal["preserve", "namespace", "flatten"]) -> str:
+        """Target identifier used for output names and delegate references."""
+        if layout == "flatten":
+            return self.name
+        if layout == "namespace":
+            return self.canonical_id.replace("/", "__")
+        return self.canonical_id
+
+    def install_relative_path(self) -> str:
+        """Canonical install path beneath `.agents/roles`."""
+        if self.relative_path:
+            return self.relative_path
+        return f"{self.name}.md"
+
+    def declared_delegate_refs(self) -> list[str]:
+        """Return raw delegate references declared in capabilities."""
+        delegates: list[str] = []
+        seen: set[str] = set()
+        for capability in self.capabilities:
+            if not isinstance(capability, dict) or "delegate" not in capability:
+                continue
+            for ref in capability.get("delegate") or []:
+                if ref and ref not in seen:
+                    seen.add(ref)
+                    delegates.append(ref)
+        return delegates
 
 
 class TargetConfig(BaseModel, frozen=True):
@@ -46,15 +105,16 @@ class TargetConfig(BaseModel, frozen=True):
     name: str
     enabled: bool = True
     output_dir: str = "."
-    model_map: dict[str, str] = {}
-    capability_map: dict[str, dict[str, bool]] = {}
+    output_layout: Literal["preserve", "namespace", "flatten"] = "preserve"
+    model_map: dict[str, str] = Field(default_factory=dict)
+    capability_map: dict[str, dict[str, bool]] = Field(default_factory=dict)
 
 
 class ProjectConfig(BaseModel, frozen=True):
     """Full parsed roles.toml configuration."""
 
     agents_dir: str = ".agents/roles"
-    targets: dict[str, TargetConfig] = {}
+    targets: dict[str, TargetConfig] = Field(default_factory=dict)
 
 
 class OutputFile(BaseModel, frozen=True):

--- a/src/agent_caster/topology.py
+++ b/src/agent_caster/topology.py
@@ -1,0 +1,243 @@
+"""Shared role topology helpers for layout and delegation validation."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import PurePosixPath
+
+from agent_caster.models import AgentDef, TargetConfig
+
+_LEVEL_RE = re.compile(r"[Ll]?(\d+)$")
+
+
+class TopologyError(ValueError):
+    """Raised when role hierarchy or delegation metadata is invalid."""
+
+
+def validate_agents(agents: list[AgentDef]) -> dict[str, list[AgentDef]]:
+    """Validate role hierarchy/delegation metadata and return a resolved graph."""
+    by_id = _build_id_index(agents)
+    by_name = _build_name_index(agents)
+    graph: dict[str, list[AgentDef]] = {}
+    incoming: dict[str, list[AgentDef]] = defaultdict(list)
+
+    for agent in agents:
+        delegates = resolve_delegate_targets(agent, by_id=by_id, by_name=by_name)
+        allowed_children = resolve_allowed_children(agent, by_id=by_id, by_name=by_name)
+        _validate_agent_conflicts(agent, delegates, allowed_children)
+
+        if allowed_children:
+            allowed_ids = {child.canonical_id for child in allowed_children}
+            for child in delegates:
+                if child.canonical_id not in allowed_ids:
+                    raise TopologyError(
+                        f"Agent '{agent.canonical_id}' delegates to '{child.canonical_id}' "
+                        "outside its allowed_children policy"
+                    )
+
+        for child in delegates:
+            if not child.hierarchy.callable:
+                raise TopologyError(
+                    f"Agent '{agent.canonical_id}' delegates to non-callable role "
+                    f"'{child.canonical_id}'"
+                )
+            if _is_upward_edge(agent, child):
+                raise TopologyError(
+                    f"Agent '{agent.canonical_id}' cannot delegate upward to '{child.canonical_id}'"
+                )
+            incoming[child.canonical_id].append(agent)
+
+        graph[agent.canonical_id] = delegates
+
+    _detect_cycles(graph)
+    longest_paths = _longest_delegation_paths(graph)
+
+    for agent in agents:
+        if not agent.hierarchy.scheduled and not agent.hierarchy.callable:
+            raise TopologyError(f"Agent '{agent.canonical_id}' is neither scheduled nor callable")
+
+        if not agent.hierarchy.callable and incoming.get(agent.canonical_id):
+            callers = ", ".join(parent.canonical_id for parent in incoming[agent.canonical_id])
+            raise TopologyError(
+                f"Agent '{agent.canonical_id}' is non-callable but is delegated to by {callers}"
+            )
+
+        max_depth = agent.hierarchy.max_delegate_depth
+        if max_depth is not None and longest_paths[agent.canonical_id] > max_depth:
+            raise TopologyError(
+                f"Agent '{agent.canonical_id}' exceeds max_delegate_depth={max_depth}"
+            )
+
+    return graph
+
+
+def validate_output_layout(agents: list[AgentDef], config: TargetConfig) -> None:
+    """Ensure the selected output layout produces unique target identifiers."""
+    seen: dict[str, str] = {}
+    for agent in agents:
+        output_id = agent.output_id(config.output_layout)
+        existing = seen.get(output_id)
+        if existing is not None:
+            raise TopologyError(
+                f"Output layout '{config.output_layout}' maps both '{existing}' and "
+                f"'{agent.canonical_id}' to '{output_id}'"
+            )
+        seen[output_id] = agent.canonical_id
+
+
+def resolve_delegate_targets(
+    agent: AgentDef,
+    *,
+    by_id: dict[str, AgentDef],
+    by_name: dict[str, list[AgentDef]],
+) -> list[AgentDef]:
+    """Resolve raw delegate references into concrete target agents."""
+    return _resolve_refs(agent.declared_delegate_refs(), by_id=by_id, by_name=by_name)
+
+
+def resolve_allowed_children(
+    agent: AgentDef,
+    *,
+    by_id: dict[str, AgentDef],
+    by_name: dict[str, list[AgentDef]],
+) -> list[AgentDef]:
+    """Resolve allowed_children into concrete target agents."""
+    return _resolve_refs(agent.hierarchy.allowed_children, by_id=by_id, by_name=by_name)
+
+
+def build_output_path(agent: AgentDef, *, base_dir: str, suffix: str, config: TargetConfig) -> str:
+    """Return the target output path for an agent under the selected layout."""
+    output_id = agent.output_id(config.output_layout)
+    if config.output_layout == "preserve":
+        return f"{base_dir}/{output_id}{suffix}"
+    return f"{base_dir}/{PurePosixPath(output_id).name}{suffix}"
+
+
+def _build_id_index(agents: list[AgentDef]) -> dict[str, AgentDef]:
+    by_id: dict[str, AgentDef] = {}
+    for agent in agents:
+        existing = by_id.get(agent.canonical_id)
+        if existing is not None:
+            raise TopologyError(
+                f"Duplicate canonical role id '{agent.canonical_id}' for "
+                f"'{existing.name}' and '{agent.name}'"
+            )
+        by_id[agent.canonical_id] = agent
+    return by_id
+
+
+def _build_name_index(agents: list[AgentDef]) -> dict[str, list[AgentDef]]:
+    by_name: dict[str, list[AgentDef]] = defaultdict(list)
+    for agent in agents:
+        by_name[agent.name].append(agent)
+    return by_name
+
+
+def _resolve_refs(
+    refs: list[str],
+    *,
+    by_id: dict[str, AgentDef],
+    by_name: dict[str, list[AgentDef]],
+) -> list[AgentDef]:
+    resolved: list[AgentDef] = []
+    seen: set[str] = set()
+    for ref in refs:
+        target = _resolve_ref(ref, by_id=by_id, by_name=by_name)
+        if target.canonical_id in seen:
+            continue
+        seen.add(target.canonical_id)
+        resolved.append(target)
+    return resolved
+
+
+def _resolve_ref(
+    ref: str,
+    *,
+    by_id: dict[str, AgentDef],
+    by_name: dict[str, list[AgentDef]],
+) -> AgentDef:
+    normalized = str(PurePosixPath(ref.strip()).with_suffix(""))
+    if normalized in by_id:
+        return by_id[normalized]
+
+    matches = by_name.get(normalized, [])
+    if not matches:
+        raise TopologyError(f"Unknown role reference '{ref}'")
+    if len(matches) > 1:
+        options = ", ".join(agent.canonical_id for agent in matches)
+        raise TopologyError(f"Ambiguous role reference '{ref}'. Use one of: {options}")
+    return matches[0]
+
+
+def _validate_agent_conflicts(
+    agent: AgentDef,
+    delegates: list[AgentDef],
+    allowed_children: list[AgentDef],
+) -> None:
+    if agent.hierarchy.role_class == "leaf" and (delegates or allowed_children):
+        raise TopologyError(
+            f"Leaf agent '{agent.canonical_id}' cannot declare delegates or allowed_children"
+        )
+
+    if agent.hierarchy.max_delegate_depth == 0 and delegates:
+        raise TopologyError(
+            f"Agent '{agent.canonical_id}' declares delegates but max_delegate_depth=0"
+        )
+
+
+def _is_upward_edge(parent: AgentDef, child: AgentDef) -> bool:
+    parent_level = _parse_level(parent.hierarchy.level)
+    child_level = _parse_level(child.hierarchy.level)
+    if parent_level is None or child_level is None:
+        return False
+    return child_level <= parent_level
+
+
+def _parse_level(level: str | int | None) -> int | None:
+    if level is None:
+        return None
+    if isinstance(level, int):
+        return level
+    match = _LEVEL_RE.fullmatch(level.strip())
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _detect_cycles(graph: dict[str, list[AgentDef]]) -> None:
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(node: str, trail: list[str]) -> None:
+        if node in visited:
+            return
+        if node in visiting:
+            cycle = " -> ".join([*trail, node])
+            raise TopologyError(f"Delegation cycle detected: {cycle}")
+
+        visiting.add(node)
+        for child in graph.get(node, []):
+            visit(child.canonical_id, [*trail, node])
+        visiting.remove(node)
+        visited.add(node)
+
+    for node in graph:
+        visit(node, [])
+
+
+def _longest_delegation_paths(graph: dict[str, list[AgentDef]]) -> dict[str, int]:
+    cache: dict[str, int] = {}
+
+    def longest(node: str) -> int:
+        if node in cache:
+            return cache[node]
+        children = graph.get(node, [])
+        if not children:
+            cache[node] = 0
+            return 0
+        depth = 1 + max(longest(child.canonical_id) for child in children)
+        cache[node] = depth
+        return depth
+
+    return {node: longest(node) for node in graph}

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2,7 +2,7 @@
 
 from agent_caster.adapters.claude import ClaudeAdapter
 from agent_caster.groups import SAFE_BASH_PATTERNS
-from agent_caster.models import AgentDef
+from agent_caster.models import AgentDef, TargetConfig
 
 
 def test_cast_aligner(sample_aligner, claude_config, snapshot):
@@ -22,7 +22,14 @@ def test_cast_explorer_with_bash(sample_explorer, claude_config, snapshot):
 
 def test_cast_orchestrator_with_delegates(sample_orchestrator, claude_config, snapshot):
     adapter = ClaudeAdapter()
-    outputs = adapter.cast([sample_orchestrator], claude_config)
+    outputs = adapter.cast(
+        [
+            sample_orchestrator,
+            AgentDef(name="explorer", description="Explorer"),
+            AgentDef(name="aligner", description="Aligner"),
+        ],
+        claude_config,
+    )
     assert outputs[0].content == snapshot
 
 
@@ -97,3 +104,38 @@ def test_default_model_map():
     adapter = ClaudeAdapter()
     assert "reasoning" in adapter.default_model_map
     assert "coding" in adapter.default_model_map
+
+
+def test_cast_nested_agent_preserves_relative_path(claude_config):
+    agent = AgentDef(name="scout", description="Scout", relative_path="l2/scout.md")
+    adapter = ClaudeAdapter()
+    outputs = adapter.cast([agent], claude_config)
+    assert outputs[0].path == ".claude/agents/l2/scout.md"
+
+
+def test_cast_namespace_layout_uses_namespaced_delegate_ids() -> None:
+    adapter = ClaudeAdapter()
+    config = TargetConfig(
+        name="claude",
+        output_layout="namespace",
+        model_map={"reasoning": "opus", "coding": "sonnet"},
+    )
+    agents = [
+        AgentDef(
+            name="orchestrator",
+            description="Orchestrator",
+            role="primary",
+            relative_path="l1/orchestrator.md",
+            capabilities=[{"delegate": ["worker"]}],
+        ),
+        AgentDef(
+            name="worker",
+            description="Worker",
+            relative_path="l3/worker.md",
+        ),
+    ]
+
+    outputs = adapter.cast(agents, config)
+    by_path = {output.path: output.content for output in outputs}
+    assert ".claude/agents/l1__orchestrator.md" in by_path
+    assert "Task(l3__worker)" in by_path[".claude/agents/l1__orchestrator.md"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,40 @@ def test_add_with_explicit_target(tmp_path):
     assert (project / ".claude" / "agents" / "explorer.md").is_file()
 
 
+def test_add_preserves_nested_role_paths_and_cast_output(tmp_path):
+    source = tmp_path / "source"
+    roles = source / "roles"
+    (roles / "l2").mkdir(parents=True)
+    (roles / "l3").mkdir(parents=True)
+    (roles / "l2" / "lead.md").write_text(
+        "---\nname: lead\ndescription: Lead\nrole: subagent\nlevel: L2\n---\n# Lead\n"
+    )
+    (roles / "l3" / "worker.md").write_text(
+        "---\nname: worker\ndescription: Worker\nrole: subagent\nlevel: L3\n---\n# Worker\n"
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "add",
+            str(source),
+            "--yes",
+            "--target",
+            "claude",
+            "--project-dir",
+            str(project),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (project / ".agents" / "roles" / "l2" / "lead.md").is_file()
+    assert (project / ".agents" / "roles" / "l3" / "worker.md").is_file()
+    assert (project / ".claude" / "agents" / "l2" / "lead.md").is_file()
+    assert (project / ".claude" / "agents" / "l3" / "worker.md").is_file()
+
+
 # -- list command --------------------------------------------------------------
 
 
@@ -114,6 +148,7 @@ def test_list_agents(tmp_path):
     result = runner.invoke(app, ["list", "--project-dir", str(tmp_path)])
     assert result.exit_code == 0
     assert "explorer" in result.output
+    assert "ID" in result.output
 
 
 def test_list_no_agents(tmp_path):
@@ -178,6 +213,46 @@ def test_remove_agent(tmp_path):
     )
     assert result.exit_code == 0
     assert not (agents_dir / "explorer.md").exists()
+
+
+def test_remove_nested_agent_by_canonical_id(tmp_path):
+    agents_dir = tmp_path / ".agents" / "roles" / "l2"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "worker.md").write_text("---\nname: worker\n---\n# E")
+
+    result = runner.invoke(
+        app,
+        [
+            "remove",
+            "l2/worker",
+            "--yes",
+            "--project-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert not (agents_dir / "worker.md").exists()
+
+
+def test_remove_ambiguous_name_requires_canonical_id(tmp_path):
+    left = tmp_path / ".agents" / "roles" / "l2"
+    right = tmp_path / ".agents" / "roles" / "l3"
+    left.mkdir(parents=True)
+    right.mkdir(parents=True)
+    (left / "worker.md").write_text("---\nname: worker\n---\n# L2")
+    (right / "worker.md").write_text("---\nname: worker\n---\n# L3")
+
+    result = runner.invoke(
+        app,
+        [
+            "remove",
+            "worker",
+            "--project-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Ambiguous agent name" in result.output
 
 
 def test_remove_nonexistent(tmp_path):
@@ -357,6 +432,55 @@ def test_cast_uses_refit_toml_config(tmp_path):
     assert agent_file.is_file()
     content = agent_file.read_text()
     assert "toml-coding" in content
+
+
+def test_cast_namespace_layout_avoids_nested_name_collisions(tmp_path):
+    agents_dir = tmp_path / ".agents" / "roles"
+    (agents_dir / "l2").mkdir(parents=True)
+    (agents_dir / "l3").mkdir(parents=True)
+    (agents_dir / "l2" / "worker.md").write_text(
+        "---\nname: worker\ndescription: L2 worker\n---\n# L2 Worker\n"
+    )
+    (agents_dir / "l3" / "worker.md").write_text(
+        "---\nname: worker\ndescription: L3 worker\n---\n# L3 Worker\n"
+    )
+    (tmp_path / "roles.toml").write_text(
+        "[targets.claude]\n"
+        'output_layout = "namespace"\n'
+        "[targets.claude.model_map]\n"
+        'reasoning = "opus"\n'
+        'coding = "sonnet"\n'
+    )
+
+    result = runner.invoke(
+        app,
+        ["cast", "--target", "claude", "--project-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude" / "agents" / "l2__worker.md").is_file()
+    assert (tmp_path / ".claude" / "agents" / "l3__worker.md").is_file()
+
+
+def test_cast_flatten_layout_rejects_nested_name_collisions(tmp_path):
+    agents_dir = tmp_path / ".agents" / "roles"
+    (agents_dir / "l2").mkdir(parents=True)
+    (agents_dir / "l3").mkdir(parents=True)
+    (agents_dir / "l2" / "worker.md").write_text("---\nname: worker\n---\n# L2 Worker\n")
+    (agents_dir / "l3" / "worker.md").write_text("---\nname: worker\n---\n# L3 Worker\n")
+    (tmp_path / "roles.toml").write_text(
+        "[targets.claude]\n"
+        'output_layout = "flatten"\n'
+        "[targets.claude.model_map]\n"
+        'reasoning = "opus"\n'
+        'coding = "sonnet"\n'
+    )
+
+    result = runner.invoke(
+        app,
+        ["cast", "--target", "claude", "--project-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+    assert "maps both" in result.output
 
 
 def test_add_opencode_prompts_for_model(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ def test_opencode_target_config(fixtures_dir):
     oc = config.targets["opencode"]
     assert oc.enabled is True
     assert oc.output_dir == "."
+    assert oc.output_layout == "preserve"
     assert oc.model_map["reasoning"] == "github-copilot/claude-opus-4.6"
     assert oc.model_map["coding"] == "github-copilot/gpt-5.2-codex"
 
@@ -67,3 +68,17 @@ def test_find_config_prefers_canonical_over_legacy(tmp_path):
 def test_find_config_returns_none_when_absent(tmp_path):
     """find_config returns None if neither config file exists."""
     assert find_config(tmp_path) is None
+
+
+def test_target_output_layout_parsed(tmp_path):
+    config_path = tmp_path / CONFIG_FILENAME
+    config_path.write_text(
+        "[targets.claude]\n"
+        'output_layout = "namespace"\n'
+        "[targets.claude.model_map]\n"
+        'reasoning = "opus"\n'
+        'coding = "sonnet"\n'
+    )
+
+    config = load_config(config_path)
+    assert config.targets["claude"].output_layout == "namespace"

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -86,6 +86,13 @@ def test_output_path_uses_agent_name():
     assert outputs[0].path == ".cursor/agents/my-agent.mdc"
 
 
+def test_output_path_preserves_relative_role_path():
+    agent = AgentDef(name="worker", description="Test", relative_path="l3/worker.md")
+    adapter = CursorAdapter()
+    outputs = adapter.cast([agent], CURSOR_CONFIG)
+    assert outputs[0].path == ".cursor/agents/l3/worker.mdc"
+
+
 def test_model_map_ignored():
     """Cursor adapter ignores model_map — Cursor selects model globally."""
     config_with_model = TargetConfig(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,6 +22,7 @@ def test_parse_explorer(fixtures_dir):
     assert agent.role == "subagent"
     assert agent.model.tier == "reasoning"
     assert agent.model.temperature == 0.05
+    assert agent.canonical_id == "explorer"
     assert "repomix-explorer" in agent.skills
     assert "read-code" in agent.capabilities
     assert agent.prompt_content.startswith("# Explorer")
@@ -119,6 +120,11 @@ def test_load_agents_recursive(tmp_path: Path) -> None:
     assert "team-a-scout" in names
     assert "deep-worker" in names
     assert len(agents) == 3
+    assert {a.canonical_id for a in agents} == {
+        "root-agent",
+        "team-a/scout",
+        "team-a/deep/worker",
+    }
 
 
 def test_load_agents_recursive_skips_bad_nested(tmp_path: Path) -> None:
@@ -146,3 +152,31 @@ def test_custom_tier_accepted(tmp_path: Path) -> None:
     agents = load_agents(agents_dir)
     assert len(agents) == 1
     assert agents[0].model.tier == "deep"
+
+
+def test_parse_hierarchy_metadata(tmp_path: Path) -> None:
+    roles_dir = tmp_path / "roles"
+    nested = roles_dir / "l2"
+    nested.mkdir(parents=True)
+    agent_file = nested / "lead.md"
+    agent_file.write_text(
+        "---\n"
+        "name: lead\n"
+        "level: L2\n"
+        "class: lead\n"
+        "scheduled: false\n"
+        "callable: true\n"
+        "max_delegate_depth: 1\n"
+        "allowed_children:\n"
+        "  - l3/worker\n"
+        "---\n"
+        "# Lead\n"
+    )
+
+    agent = parse_agent_file(agent_file, agents_dir=roles_dir)
+    assert agent.canonical_id == "l2/lead"
+    assert agent.relative_path == "l2/lead.md"
+    assert agent.hierarchy.level == "L2"
+    assert agent.hierarchy.role_class == "lead"
+    assert agent.hierarchy.max_delegate_depth == 1
+    assert agent.hierarchy.allowed_children == ["l3/worker"]

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -21,7 +21,14 @@ def test_cast_aligner_no_bash(sample_aligner, opencode_config, snapshot):
 
 def test_cast_orchestrator_with_delegates(sample_orchestrator, opencode_config, snapshot):
     adapter = OpenCodeAdapter()
-    outputs = adapter.cast([sample_orchestrator], opencode_config)
+    outputs = adapter.cast(
+        [
+            sample_orchestrator,
+            AgentDef(name="explorer", description="Explorer"),
+            AgentDef(name="aligner", description="Aligner"),
+        ],
+        opencode_config,
+    )
     assert outputs[0].content == snapshot
 
 
@@ -194,3 +201,34 @@ def test_custom_tier_overrides_if_in_model_map():
     adapter = OpenCodeAdapter()
     resolved = adapter._resolve_model(agent.model, config.model_map)
     assert resolved == "model-ultra"
+
+
+def test_cast_nested_agent_preserves_relative_path(opencode_config):
+    agent = AgentDef(name="scout", description="Scout", relative_path="l2/scout.md")
+    adapter = OpenCodeAdapter()
+    outputs = adapter.cast([agent], opencode_config)
+    assert outputs[0].path == ".opencode/agents/l2/scout.md"
+
+
+def test_cast_namespace_layout_uses_namespaced_task_permissions() -> None:
+    adapter = OpenCodeAdapter()
+    config = TargetConfig(
+        name="opencode",
+        output_layout="namespace",
+        model_map={"reasoning": "model-r", "coding": "model-c"},
+    )
+    agents = [
+        AgentDef(
+            name="orchestrator",
+            description="Orchestrator",
+            role="primary",
+            relative_path="l1/orchestrator.md",
+            capabilities=[{"delegate": ["worker"]}],
+        ),
+        AgentDef(name="worker", description="Worker", relative_path="l3/worker.md"),
+    ]
+
+    outputs = adapter.cast(agents, config)
+    by_path = {output.path: output.content for output in outputs}
+    assert ".opencode/agents/l1__orchestrator.md" in by_path
+    assert '"l3__worker": allow' in by_path[".opencode/agents/l1__orchestrator.md"]

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,0 +1,102 @@
+"""Tests for shared role topology helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_caster.models import AgentDef, HierarchyConfig, TargetConfig
+from agent_caster.topology import TopologyError, validate_agents, validate_output_layout
+
+
+def test_validate_agents_resolves_hierarchy_graph() -> None:
+    agents = [
+        AgentDef(
+            name="orchestrator",
+            relative_path="l1/orchestrator.md",
+            hierarchy=HierarchyConfig(
+                level="L1",
+                role_class="main",
+                scheduled=True,
+                callable=True,
+                max_delegate_depth=2,
+                allowed_children=["l2/lead"],
+            ),
+            capabilities=[{"delegate": ["lead"]}],
+        ),
+        AgentDef(
+            name="lead",
+            relative_path="l2/lead.md",
+            hierarchy=HierarchyConfig(level="L2", role_class="lead", max_delegate_depth=1),
+            capabilities=[{"delegate": ["l3/worker"]}],
+        ),
+        AgentDef(
+            name="worker",
+            relative_path="l3/worker.md",
+            hierarchy=HierarchyConfig(level="L3", role_class="leaf", max_delegate_depth=0),
+        ),
+    ]
+
+    graph = validate_agents(agents)
+    assert [child.canonical_id for child in graph["l1/orchestrator"]] == ["l2/lead"]
+    assert [child.canonical_id for child in graph["l2/lead"]] == ["l3/worker"]
+    assert graph["l3/worker"] == []
+
+
+def test_validate_agents_rejects_unknown_delegate() -> None:
+    agent = AgentDef(
+        name="lead",
+        relative_path="l2/lead.md",
+        hierarchy=HierarchyConfig(level="L2"),
+        capabilities=[{"delegate": ["missing"]}],
+    )
+
+    with pytest.raises(TopologyError, match="Unknown role reference"):
+        validate_agents([agent])
+
+
+def test_validate_agents_rejects_upward_delegate() -> None:
+    agents = [
+        AgentDef(
+            name="lead",
+            relative_path="l2/lead.md",
+            hierarchy=HierarchyConfig(level="L2"),
+            capabilities=[{"delegate": ["l1/main"]}],
+        ),
+        AgentDef(
+            name="main",
+            relative_path="l1/main.md",
+            hierarchy=HierarchyConfig(level="L1"),
+        ),
+    ]
+
+    with pytest.raises(TopologyError, match="cannot delegate upward"):
+        validate_agents(agents)
+
+
+def test_validate_agents_rejects_cycles() -> None:
+    agents = [
+        AgentDef(
+            name="a",
+            relative_path="l1/a.md",
+            capabilities=[{"delegate": ["l2/b"]}],
+        ),
+        AgentDef(
+            name="b",
+            relative_path="l2/b.md",
+            capabilities=[{"delegate": ["l1/a"]}],
+        ),
+    ]
+
+    with pytest.raises(TopologyError, match="Delegation cycle detected"):
+        validate_agents(agents)
+
+
+def test_validate_output_layout_rejects_flatten_collisions() -> None:
+    agents = [
+        AgentDef(name="worker", relative_path="l2/worker.md"),
+        AgentDef(name="worker", relative_path="l3/worker.md"),
+    ]
+    config = TargetConfig(name="claude", output_layout="flatten")
+
+    with pytest.raises(TopologyError, match="maps both"):
+        validate_output_layout(agents, config)

--- a/tests/test_windsurf.py
+++ b/tests/test_windsurf.py
@@ -55,6 +55,13 @@ def test_output_path_uses_agent_name():
     assert outputs[0].path == ".windsurf/rules/my-agent.md"
 
 
+def test_output_path_preserves_relative_role_path():
+    agent = AgentDef(name="worker", description="Test", relative_path="l3/worker.md")
+    adapter = WindsurfAdapter()
+    outputs = adapter.cast([agent], WINDSURF_CONFIG)
+    assert outputs[0].path == ".windsurf/rules/l3/worker.md"
+
+
 def test_default_trigger_is_model_decision():
     """Default activation trigger should be model_decision."""
     agent = AgentDef(


### PR DESCRIPTION
## Summary

Add first-class hierarchy metadata to canonical role definitions, including level, class, scheduled, callable, max_delegate_depth, and allowed_children.
Preserve source role path semantics through canonical role IDs and configurable cast output layouts: preserve, namespace, and flatten.
Validate delegation graphs at cast time, including unknown edges, ambiguity, upward delegation, cycles, depth violations, and hierarchy capability conflicts.
Update CLI install/cast/remove flows to preserve nested role paths and surface canonical role IDs consistently.
Add regression coverage for hierarchy parsing, topology validation, path-preserving cast output, namespace collision handling, and nested CLI workflows.
## Why

marrow-core needs agent-caster to understand hierarchy intent directly instead of relying on repo-local contracts. These changes make hierarchy metadata first-class, keep path/namespace meaning after discovery, and move delegation-policy failures from runtime surprises to cast-time validation. This aligns directly with the gaps described in #18, #19, and #20.agent_caster_issue18_pretty.json:1-7 agent_caster_issue19_pretty.json:1-7 agent_caster_issue20_pretty.json:1-7

## Testing

just ci
uv run pytest tests/test_loader.py tests/test_config.py tests/test_topology.py tests/test_claude.py tests/test_opencode.py tests/test_cursor.py tests/test_windsurf.py tests/test_cli.py
Closes #18
Closes #19
Closes #20