### PR TITLE
🐛 fix(claude): use canonical_id for name/delegate refs + simplify config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,6 @@ Project configuration lives in `roles.toml`.
 roles_dir = ".agents/roles"
 
 [targets.claude]
-output_layout = "preserve"
 
 [targets.claude.model_map]
 reasoning = "claude-opus-4-6"
@@ -18,19 +17,20 @@ coding = "claude-sonnet-4"
 
 ## Project keys
 
-- `roles_dir`: canonical role install directory inside the project
+- `roles_dir`: role definitions directory in the **source** repository (used by `find_roles_dir` during `add`)
 
 ## Install scopes
 
-- project scope is the default install target and resolves from `roles.toml` or `.agents/roles`
+- project scope is the default install target, always `.agents/roles`
 - user scope uses `~/.agents/roles` and is selected with `-g` or `--global`
-- render merges user and project roles by canonical id, with project roles overriding user roles
+- render operates on the installed scope; `add` only renders roles from the scope that was just installed
 - list and remove operate on one scope at a time: default project, `-g` for user
 
 ## Local sources
 
 - local installs use `role-forge add ./path` or `role-forge add /absolute/path`
 - local sources are copied into the selected install scope; symlink installs are not supported
+- if source and destination are the same file, the copy is skipped
 
 ## Hygiene commands
 
@@ -41,8 +41,6 @@ coding = "claude-sonnet-4"
 ## Target keys
 
 - `enabled`: target toggle, default `true`
-- `output_dir`: base output directory, default `.`
-- `output_layout`: `preserve`, `namespace`, or `flatten`
 - `model_map`: logical model tiers to target-specific identifiers
 - `capability_map`: project-defined capability expansion for adapters that support it
 
@@ -51,12 +49,14 @@ coding = "claude-sonnet-4"
 When reading a source repository, `role-forge` resolves role files in this order:
 
 1. `roles.toml` with `project.roles_dir`
-2. fallback `roles/`
+2. `.agents/roles/` directory
+3. fallback `roles/`
 
-## Output layout modes
+## Output layout
 
-- `preserve`: keep nested paths such as `l2/worker`
-- `namespace`: flatten path separators into names like `l2__worker`
-- `flatten`: use bare `name`, rejecting collisions
+Each adapter defines its own output layout:
+
+- Claude and Copilot default to `namespace` (e.g. `directors__bug-fix.md`)
+- Other adapters default to `preserve` (e.g. `directors/bug-fix.md`)
 
 `role-forge` validates layout collisions before writing files.

--- a/src/role_forge/adapters/base.py
+++ b/src/role_forge/adapters/base.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from role_forge.models import AgentDef, ModelConfig, OutputFile, TargetConfig
 from role_forge.topology import build_output_path, validate_agents, validate_output_layout
+
+OutputLayout = Literal["preserve", "namespace", "flatten"]
 
 
 class BaseAdapter(ABC):
@@ -16,26 +18,15 @@ class BaseAdapter(ABC):
     base_dir: ClassVar[str]
     file_suffix: ClassVar[str]
     default_model_map: ClassVar[dict[str, str]] = {}
-    default_output_layout: ClassVar[str] = "preserve"
+    default_output_layout: ClassVar[OutputLayout] = "preserve"
     requires_model_map: ClassVar[bool] = True
     prompt_separator: ClassVar[str] = "\n"
 
-    def _effective_config(self, config: TargetConfig) -> TargetConfig:
-        """Apply adapter defaults to the target configuration.
-
-        When the caller has not explicitly set ``output_layout`` (i.e. it is
-        ``None``), the adapter's own ``default_output_layout`` takes
-        precedence.
-        """
-        if config.output_layout is None:
-            return config.model_copy(update={"output_layout": self.default_output_layout})
-        return config
-
     def cast(self, agents: list[AgentDef], config: TargetConfig) -> list[OutputFile]:
         """Validate topology and render all agents for the target platform."""
-        config = self._effective_config(config)
+        layout = self.default_output_layout
         delegation_graph = validate_agents(agents)
-        validate_output_layout(agents, config)
+        validate_output_layout(agents, layout)
 
         outputs: list[OutputFile] = []
         for agent in agents:
@@ -49,7 +40,7 @@ class BaseAdapter(ABC):
                         agent,
                         base_dir=self.base_dir,
                         suffix=self.file_suffix,
-                        config=config,
+                        layout=layout,
                     ),
                     content=self.render_agent(agent, config, delegates),
                 )
@@ -62,7 +53,7 @@ class BaseAdapter(ABC):
         Override in subclasses when the target platform resolves agents by
         name rather than by output path.
         """
-        return target.output_id(config.output_layout)
+        return target.output_id(self.default_output_layout)
 
     @staticmethod
     def _resolve_model(model: ModelConfig, model_map: dict[str, str]) -> str:

--- a/src/role_forge/adapters/base.py
+++ b/src/role_forge/adapters/base.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from role_forge.models import AgentDef, ModelConfig, OutputFile, TargetConfig
-from role_forge.topology import build_output_path, validate_agents, validate_output_layout
-
-OutputLayout = Literal["preserve", "namespace", "flatten"]
+from role_forge.topology import (
+    OutputLayout,
+    build_output_path,
+    validate_agents,
+    validate_output_layout,
+)
 
 
 class BaseAdapter(ABC):

--- a/src/role_forge/adapters/claude.py
+++ b/src/role_forge/adapters/claude.py
@@ -43,7 +43,7 @@ class ClaudeAdapter(BaseAdapter):
 
     def _delegate_ref(self, target: AgentDef, config: TargetConfig) -> str:
         """Claude Code resolves Task() targets by the agent's name: field."""
-        return target.name
+        return target.canonical_id
 
     def _expand_capabilities(
         self,
@@ -107,7 +107,7 @@ class ClaudeAdapter(BaseAdapter):
         tools = self._map_tool_ids(spec)
         bash_patterns = list(spec.bash_patterns)
 
-        name = agent.name
+        name = agent.canonical_id
         description = agent.description
         model = self._resolve_model(agent.model, config.model_map)
         allowed_tools = self._build_allowed_tools(tools, bash_patterns, delegates)

--- a/src/role_forge/cli.py
+++ b/src/role_forge/cli.py
@@ -92,29 +92,10 @@ def _resolve_target_config(
     from role_forge.config import find_config, load_config
     from role_forge.models import TargetConfig
 
-    def _is_within_root(root: Path, candidate: Path) -> bool:
-        try:
-            candidate.relative_to(root)
-            return True
-        except ValueError:
-            return False
-
-    def _validate_output_dir(cfg: TargetConfig, *, root: Path) -> TargetConfig:
-        if Path(cfg.output_dir).is_absolute():
-            _error(f"Target '{target_name}' output_dir must be project-relative: {cfg.output_dir}")
-            raise typer.Exit(1)
-        output_path = (root / cfg.output_dir).resolve()
-        if not _is_within_root(root.resolve(), output_path):
-            _error(
-                f"Target '{target_name}' output_dir points outside the project: {cfg.output_dir}"
-            )
-            raise typer.Exit(1)
-        return cfg
-
-    def _accept_config(cfg: TargetConfig, *, root: Path) -> TargetConfig | None:
+    def _accept_config(cfg: TargetConfig) -> TargetConfig | None:
         if adapter.requires_model_map and not cfg.model_map:
             return None
-        return _validate_output_dir(cfg, root=root)
+        return cfg
 
     # Prefer source repo roles.toml when rendering after add/update
     if source_project is not None:
@@ -123,7 +104,7 @@ def _resolve_target_config(
             src_config = load_config(src_config_path)
             if target_name in src_config.targets:
                 cfg = src_config.targets[target_name]
-                accepted = _accept_config(cfg, root=project)
+                accepted = _accept_config(cfg)
                 if accepted is not None:
                     return accepted
 
@@ -132,26 +113,19 @@ def _resolve_target_config(
         project_config = load_config(config_path)
         if target_name in project_config.targets:
             cfg = project_config.targets[target_name]
-            accepted = _accept_config(cfg, root=project)
+            accepted = _accept_config(cfg)
             if accepted is not None:
                 return accepted
 
     if adapter.default_model_map:
-        return _validate_output_dir(
-            TargetConfig(
-                name=target_name,
-                enabled=True,
-                output_dir=".",
-                model_map=adapter.default_model_map,
-            ),
-            root=project,
+        return TargetConfig(
+            name=target_name,
+            enabled=True,
+            model_map=adapter.default_model_map,
         )
 
     if not adapter.requires_model_map:
-        return _validate_output_dir(
-            TargetConfig(name=target_name, enabled=True, output_dir="."),
-            root=project,
-        )
+        return TargetConfig(name=target_name, enabled=True)
 
     _error(
         f"No model_map for '{target_name}'. Add [targets.{target_name}.model_map] to roles.toml "
@@ -269,31 +243,27 @@ def _render_agents_to_targets(
             _error(str(e))
             raise typer.Exit(1) from e
 
-        outputs_to_write = _confirm_render_overwrite(
-            project, config.output_dir, outputs, interactive
-        )
+        outputs_to_write = _confirm_render_overwrite(project, outputs, interactive)
         if outputs_to_write:
-            _write_outputs(project, outputs_to_write, config.output_dir)
+            _write_outputs(project, outputs_to_write)
         _success(f"Rendered {len(outputs)} roles -> {target_name}")
 
 
-def _confirm_render_overwrite(project: Path, output_dir: str, outputs, interactive: bool):
+def _confirm_render_overwrite(project: Path, outputs, interactive: bool):
     """If interactive and some paths exist, prompt once. Return list to write (filtered or all)."""
-    out_dir_path = project / output_dir
-    existing = [o for o in outputs if (out_dir_path / o.path).exists()]
+    existing = [o for o in outputs if (project / o.path).exists()]
     if not existing or not interactive:
         return list(outputs)
     n = len(existing)
-    display_dir = output_dir if output_dir != "." else str(project)
-    if not typer.confirm(f"Overwrite {n} existing file(s) in {display_dir}?", default=True):
-        existing_paths = {(out_dir_path / o.path).resolve() for o in existing}
-        return [o for o in outputs if (out_dir_path / o.path).resolve() not in existing_paths]
+    if not typer.confirm(f"Overwrite {n} existing file(s) in {project}?", default=True):
+        existing_paths = {(project / o.path).resolve() for o in existing}
+        return [o for o in outputs if (project / o.path).resolve() not in existing_paths]
     return list(outputs)
 
 
-def _write_outputs(project: Path, outputs, output_dir: str) -> None:
+def _write_outputs(project: Path, outputs) -> None:
     for out in outputs:
-        full_path = (project / output_dir / out.path).resolve()
+        full_path = (project / out.path).resolve()
         full_path.parent.mkdir(parents=True, exist_ok=True)
         full_path.write_text(out.content, encoding="utf-8")
 
@@ -329,7 +299,7 @@ def _format_roles_dir_error(source: str, repo_path: Path) -> str:
     return (
         f"Fetched source '{source}', but no role definitions were found.\n"
         f"  cache: {repo_path}\n"
-        "  expected: a `roles.toml` with `project.roles_dir`, or a `roles/` directory"
+        "  expected: '.agents/roles/' or 'roles/' directory"
     )
 
 
@@ -396,6 +366,10 @@ def _copy_agents(plan: InstallPlan, yes: bool, include_overwrites: bool) -> list
         assert agent.source_path is not None
         destination = plan.install_dir / agent.install_relative_path()
         destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.resolve() == agent.source_path.resolve():
+            installed.append(agent)
+            logger.info(_bullet("skipped (same file)", agent.canonical_id))
+            continue
         shutil.copy2(agent.source_path, destination)
         installed.append(agent)
         logger.info(_bullet("installed", agent.canonical_id))
@@ -446,7 +420,13 @@ def _render_after_add(
         return
     # Global install: render into home so ~/.opencode/agents etc. are populated
     render_root = Path.home() if global_install else project
-    agents = _load_merged_agents(render_root)
+    scope: Scope = "user" if global_install else "project"
+    from role_forge.loader import load_agents_in_scope
+
+    _, agents = load_agents_in_scope(render_root, scope=scope)
+    if not agents:
+        _warn("No roles to render in installed scope.")
+        return
     _render_agents_to_targets(
         render_root,
         agents,

--- a/src/role_forge/config.py
+++ b/src/role_forge/config.py
@@ -19,10 +19,7 @@ class ConfigError(Exception):
 
 def resolve_roles_dir(project: Path) -> Path:
     """Return the canonical roles directory for a project."""
-    config_path = find_config(project)
-    if config_path is None:
-        return project / ".agents" / "roles"
-    return project / load_config(config_path).roles_dir
+    return project / ".agents" / "roles"
 
 
 def find_config(project: Path) -> Path | None:
@@ -55,8 +52,6 @@ def _parse_target(name: str, raw: dict) -> TargetConfig:
     return TargetConfig(
         name=name,
         enabled=raw.get("enabled", True),
-        output_dir=raw.get("output_dir", "."),
-        output_layout=raw.get("output_layout"),
         model_map=raw.get("model_map", {}),
         capability_map=raw.get("capability_map", {}),
     )

--- a/src/role_forge/models.py
+++ b/src/role_forge/models.py
@@ -71,7 +71,7 @@ class AgentDef(BaseModel, frozen=True):
             canonical_path.parent.as_posix() if canonical_path.parent != PurePosixPath(".") else ""
         )
 
-    def output_id(self, layout: Literal["preserve", "namespace", "flatten"] | None) -> str:
+    def output_id(self, layout: Literal["preserve", "namespace", "flatten"]) -> str:
         """Target identifier used for output names and delegate references."""
         if layout == "flatten":
             return self.name
@@ -104,8 +104,6 @@ class TargetConfig(BaseModel, frozen=True):
 
     name: str
     enabled: bool = True
-    output_dir: str = "."
-    output_layout: Literal["preserve", "namespace", "flatten"] | None = None
     model_map: dict[str, str] = Field(default_factory=dict)
     capability_map: dict[str, dict[str, bool]] = Field(default_factory=dict)
 
@@ -122,5 +120,5 @@ class ProjectConfig(BaseModel, frozen=True):
 class OutputFile(BaseModel, frozen=True):
     """A file to be written by the caster."""
 
-    path: str  # relative to output_dir
+    path: str  # relative to project root
     content: str

--- a/src/role_forge/registry.py
+++ b/src/role_forge/registry.py
@@ -204,11 +204,12 @@ def _ensure_head_checked_out(repo_dir: Path, ref: str | None) -> None:
 
 
 def find_roles_dir(repo_path: Path) -> Path:
-    """Find agent definitions directory in a fetched repo.
+    """Find agent definitions directory in a fetched source repo.
 
     Priority:
-    1. roles.toml roles_dir setting
-    2. roles/ directory
+    1. roles.toml [project].roles_dir setting
+    2. .agents/roles/ directory (default install layout)
+    3. roles/ directory (legacy/simple layout)
     """
     config_path = find_config(repo_path)
     if config_path is not None:
@@ -216,12 +217,16 @@ def find_roles_dir(repo_path: Path) -> Path:
         if roles_dir.is_dir():
             return roles_dir
 
-    # Default fallback
+    roles_dir = repo_path / ".agents" / "roles"
+    if roles_dir.is_dir():
+        return roles_dir
+
+    # Legacy fallback
     roles_dir = repo_path / "roles"
     if roles_dir.is_dir():
         return roles_dir
 
     raise FileNotFoundError(
         f"No agent definitions found in {repo_path}. "
-        "Expected 'roles.toml' with roles_dir, or a roles/ directory."
+        "Expected '.agents/roles/' or 'roles/' directory."
     )

--- a/src/role_forge/topology.py
+++ b/src/role_forge/topology.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from pathlib import PurePosixPath
 
-from role_forge.models import AgentDef, TargetConfig
+from role_forge.models import AgentDef
 
 _LEVEL_RE = re.compile(r"[Ll]?(\d+)$")
 
@@ -72,15 +72,15 @@ def validate_agents(agents: list[AgentDef]) -> dict[str, list[AgentDef]]:
     return graph
 
 
-def validate_output_layout(agents: list[AgentDef], config: TargetConfig) -> None:
+def validate_output_layout(agents: list[AgentDef], layout: str) -> None:
     """Ensure the selected output layout produces unique target identifiers."""
     seen: dict[str, str] = {}
     for agent in agents:
-        output_id = agent.output_id(config.output_layout)
+        output_id = agent.output_id(layout)
         existing = seen.get(output_id)
         if existing is not None:
             raise TopologyError(
-                f"Output layout '{config.output_layout}' maps both '{existing}' and "
+                f"Output layout '{layout}' maps both '{existing}' and "
                 f"'{agent.canonical_id}' to '{output_id}'"
             )
         seen[output_id] = agent.canonical_id
@@ -106,14 +106,14 @@ def resolve_allowed_children(
     return _resolve_refs(agent.hierarchy.allowed_children, by_id=by_id, by_name=by_name)
 
 
-def build_output_path(agent: AgentDef, *, base_dir: str, suffix: str, config: TargetConfig) -> str:
+def build_output_path(agent: AgentDef, *, base_dir: str, suffix: str, layout: str) -> str:
     """Return the target output path for an agent under the selected layout."""
     base_path = PurePosixPath(base_dir)
     if base_path.is_absolute() or ".." in base_path.parts:
         raise TopologyError(f"Output base directory '{base_dir}' escapes base directory bounds")
 
-    output_id = agent.output_id(config.output_layout)
-    if config.output_layout in ("preserve", None):
+    output_id = agent.output_id(layout)
+    if layout == "preserve":
         return f"{base_dir}/{output_id}{suffix}"
     return f"{base_dir}/{PurePosixPath(output_id).name}{suffix}"
 

--- a/src/role_forge/topology.py
+++ b/src/role_forge/topology.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from pathlib import PurePosixPath
+from typing import Literal
 
 from role_forge.models import AgentDef
+
+OutputLayout = Literal["preserve", "namespace", "flatten"]
 
 _LEVEL_RE = re.compile(r"[Ll]?(\d+)$")
 
@@ -72,7 +75,7 @@ def validate_agents(agents: list[AgentDef]) -> dict[str, list[AgentDef]]:
     return graph
 
 
-def validate_output_layout(agents: list[AgentDef], layout: str) -> None:
+def validate_output_layout(agents: list[AgentDef], layout: OutputLayout) -> None:
     """Ensure the selected output layout produces unique target identifiers."""
     seen: dict[str, str] = {}
     for agent in agents:
@@ -106,7 +109,7 @@ def resolve_allowed_children(
     return _resolve_refs(agent.hierarchy.allowed_children, by_id=by_id, by_name=by_name)
 
 
-def build_output_path(agent: AgentDef, *, base_dir: str, suffix: str, layout: str) -> str:
+def build_output_path(agent: AgentDef, *, base_dir: str, suffix: str, layout: OutputLayout) -> str:
     """Return the target output path for an agent under the selected layout."""
     base_path = PurePosixPath(base_dir)
     if base_path.is_absolute() or ".." in base_path.parts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,6 @@ def opencode_config() -> TargetConfig:
     return TargetConfig(
         name="opencode",
         enabled=True,
-        output_dir=".",
         model_map={
             "reasoning": "github-copilot/claude-opus-4.6",
             "coding": "github-copilot/gpt-5.2-codex",
@@ -88,7 +87,6 @@ def claude_config() -> TargetConfig:
     return TargetConfig(
         name="claude",
         enabled=True,
-        output_dir=".",
         model_map={
             "reasoning": "opus",
             "coding": "sonnet",

--- a/tests/fixtures/roles.toml
+++ b/tests/fixtures/roles.toml
@@ -3,7 +3,6 @@ roles_dir = ".agents/roles"
 
 [targets.opencode]
 enabled = true
-output_dir = "."
 
 [targets.opencode.model_map]
 reasoning = "github-copilot/claude-opus-4.6"
@@ -15,7 +14,6 @@ gh-search = { gh_grep = true }
 
 [targets.claude]
 enabled = true
-output_dir = "."
 
 [targets.claude.model_map]
 reasoning = "opus"

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -194,12 +194,11 @@ def test_cast_nested_agent_uses_namespace_layout_by_default(claude_config):
     assert outputs[0].path == ".claude/agents/l2__scout.md"
 
 
-def test_cast_namespace_layout_uses_name_based_delegate_ids() -> None:
-    """Claude resolves Task() by agent name, regardless of output layout."""
+def test_cast_namespace_layout_uses_canonical_id_delegate_ids() -> None:
+    """Claude resolves Task() by agent canonical_id for uniqueness across namespaces."""
     adapter = ClaudeAdapter()
     config = TargetConfig(
         name="claude",
-        output_layout="namespace",
         model_map={"reasoning": "opus", "coding": "sonnet"},
     )
     agents = [
@@ -220,15 +219,16 @@ def test_cast_namespace_layout_uses_name_based_delegate_ids() -> None:
     outputs = adapter.cast(agents, config)
     by_path = {output.path: output.content for output in outputs}
     assert ".claude/agents/l1__orchestrator.md" in by_path
-    assert "Task(worker)" in by_path[".claude/agents/l1__orchestrator.md"]
+    content = by_path[".claude/agents/l1__orchestrator.md"]
+    assert "Task(l3/worker)" in content
+    assert "name: l1/orchestrator" in content
 
 
-def test_cast_preserve_layout_uses_name_based_delegate_ids() -> None:
-    """Claude resolves Task() by agent name even with nested file paths."""
+def test_cast_nested_delegates_use_canonical_id() -> None:
+    """Claude uses canonical_id for Task() refs with nested agents in same namespace."""
     adapter = ClaudeAdapter()
     config = TargetConfig(
         name="claude",
-        output_layout="preserve",
         model_map={"reasoning": "opus", "coding": "sonnet"},
     )
     agents = [
@@ -248,8 +248,7 @@ def test_cast_preserve_layout_uses_name_based_delegate_ids() -> None:
 
     outputs = adapter.cast(agents, config)
     by_path = {output.path: output.content for output in outputs}
-    assert ".claude/agents/directors/coordinator.md" in by_path
-    content = by_path[".claude/agents/directors/coordinator.md"]
-    assert "Task(precision-alignment)" in content
-    # Must NOT contain path-based reference
-    assert "Task(directors/precision-alignment)" not in content
+    assert ".claude/agents/directors__coordinator.md" in by_path
+    content = by_path[".claude/agents/directors__coordinator.md"]
+    assert "Task(directors/precision-alignment)" in content
+    assert "name: directors/coordinator" in content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -377,9 +377,7 @@ def test_render_cursor_respects_target_config_without_model_map(tmp_path):
     roles_dir = tmp_path / ".agents" / "roles"
     roles_dir.mkdir(parents=True)
     (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    (tmp_path / "roles.toml").write_text(
-        '[targets.cursor]\noutput_dir = "generated"\noutput_layout = "flatten"\n'
-    )
+    (tmp_path / "roles.toml").write_text("[targets.cursor]\nenabled = true\n")
 
     result = runner.invoke(
         app,
@@ -387,7 +385,7 @@ def test_render_cursor_respects_target_config_without_model_map(tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    agent_file = tmp_path / "generated" / ".cursor" / "agents" / "explorer.mdc"
+    agent_file = tmp_path / ".cursor" / "agents" / "explorer.mdc"
     assert agent_file.is_file()
     assert "model:" not in agent_file.read_text()
 
@@ -424,67 +422,6 @@ def test_render_fails_when_any_installed_role_is_invalid(tmp_path):
     assert result.exit_code == 1
     assert "bad.md" in result.output
     assert not (tmp_path / ".claude" / "agents" / "good.md").exists()
-
-
-def test_render_rejects_output_dir_outside_project(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    (tmp_path / "roles.toml").write_text(
-        "[targets.claude]\n"
-        'output_dir = "../outside"\n'
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 1
-    assert "outside the project" in result.output
-    assert not (tmp_path / ".claude" / "agents" / "explorer.md").exists()
-    assert not (tmp_path.parent / "outside").exists()
-
-
-def test_render_rejects_absolute_output_dir(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    outside = tmp_path / "absolute-output"
-    (tmp_path / "roles.toml").write_text(
-        "[targets.claude]\n"
-        f'output_dir = "{outside}"\n'
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 1
-    assert "project-relative" in result.output
-    assert not outside.exists()
-
-
-def test_render_allows_normalized_output_dir_inside_project(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    (tmp_path / "roles.toml").write_text(
-        '[targets.cursor]\noutput_dir = "generated/../generated-safe"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "cursor", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 0, result.output
-    assert (tmp_path / "generated-safe" / ".cursor" / "agents" / "explorer.mdc").is_file()
 
 
 def test_render_merges_user_and_project_agents(tmp_path, monkeypatch):
@@ -696,7 +633,7 @@ def test_remove_nonexistent(tmp_path):
 
 def test_render_uses_roles_toml_targets_without_flag(tmp_path):
     """render without --target should use targets from roles.toml, not filesystem detection."""
-    roles_dir = tmp_path / "roles"
+    roles_dir = tmp_path / ".agents" / "roles"
     roles_dir.mkdir(parents=True)
     (roles_dir / "explorer.md").write_text(
         "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
@@ -709,7 +646,6 @@ def test_render_uses_roles_toml_targets_without_flag(tmp_path):
 
     # But only configure opencode and claude in roles.toml
     (tmp_path / "roles.toml").write_text(
-        '[project]\nroles_dir = "roles"\n'
         "[targets.opencode]\n"
         "enabled = true\n"
         "[targets.opencode.model_map]\n"
@@ -750,7 +686,7 @@ def test_add_missing_roles_dir_message_is_actionable(monkeypatch, tmp_path):
         "Fetched source 'PFCCLab/precision-agents', but no role definitions were found"
         in result.output
     )
-    assert "expected: a `roles.toml`" in result.output
+    assert "'.agents/roles/' or 'roles/' directory" in result.output
 
 
 def test_update_global_passes_scope(monkeypatch, tmp_path):
@@ -970,11 +906,7 @@ def test_render_namespace_layout_avoids_nested_name_collisions(tmp_path):
         "---\nname: worker\ndescription: L3 worker\n---\n# L3 Worker\n"
     )
     (tmp_path / "roles.toml").write_text(
-        "[targets.claude]\n"
-        'output_layout = "namespace"\n'
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\n'
-        'coding = "sonnet"\n'
+        '[targets.claude]\n[targets.claude.model_map]\nreasoning = "opus"\ncoding = "sonnet"\n'
     )
 
     result = runner.invoke(
@@ -984,28 +916,6 @@ def test_render_namespace_layout_avoids_nested_name_collisions(tmp_path):
     assert result.exit_code == 0, result.output
     assert (tmp_path / ".claude" / "agents" / "l2__worker.md").is_file()
     assert (tmp_path / ".claude" / "agents" / "l3__worker.md").is_file()
-
-
-def test_render_flatten_layout_rejects_nested_name_collisions(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    (roles_dir / "l2").mkdir(parents=True)
-    (roles_dir / "l3").mkdir(parents=True)
-    (roles_dir / "l2" / "worker.md").write_text("---\nname: worker\n---\n# L2 Worker\n")
-    (roles_dir / "l3" / "worker.md").write_text("---\nname: worker\n---\n# L3 Worker\n")
-    (tmp_path / "roles.toml").write_text(
-        "[targets.claude]\n"
-        'output_layout = "flatten"\n'
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\n'
-        'coding = "sonnet"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(tmp_path)],
-    )
-    assert result.exit_code == 1
-    assert "maps both" in result.output
 
 
 def test_add_opencode_uses_source_repo_model_map(tmp_path):
@@ -1051,11 +961,7 @@ def test_add_cursor_uses_source_repo_target_config_without_model_map(tmp_path):
     roles = source / "roles"
     roles.mkdir(parents=True)
     (source / "roles.toml").write_text(
-        "[project]\n"
-        'roles_dir = "roles"\n\n'
-        "[targets.cursor]\n"
-        "enabled = true\n"
-        'output_dir = "generated"\n'
+        '[project]\nroles_dir = "roles"\n\n[targets.cursor]\nenabled = true\n'
     )
     (roles / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
 
@@ -1068,7 +974,7 @@ def test_add_cursor_uses_source_repo_target_config_without_model_map(tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    agent_file = project / "generated" / ".cursor" / "agents" / "explorer.mdc"
+    agent_file = project / ".cursor" / "agents" / "explorer.mdc"
     assert agent_file.is_file()
     assert "model:" not in agent_file.read_text()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,6 @@ from role_forge.config import (
 
 def test_load_config_from_fixtures(fixtures_dir):
     config = load_config(fixtures_dir / "roles.toml")
-    assert config.roles_dir == ".agents/roles"
     assert "opencode" in config.targets
     assert "claude" in config.targets
 
@@ -22,8 +21,6 @@ def test_opencode_target_config(fixtures_dir):
     config = load_config(fixtures_dir / "roles.toml")
     oc = config.targets["opencode"]
     assert oc.enabled is True
-    assert oc.output_dir == "."
-    assert oc.output_layout is None
     assert oc.model_map["reasoning"] == "github-copilot/claude-opus-4.6"
     assert oc.model_map["coding"] == "github-copilot/gpt-5.2-codex"
 
@@ -59,45 +56,8 @@ def test_find_config_returns_none_when_absent(tmp_path):
     assert find_config(tmp_path) is None
 
 
-def test_target_output_layout_parsed(tmp_path):
-    config_path = tmp_path / CONFIG_FILENAME
-    config_path.write_text(
-        "[targets.claude]\n"
-        'output_layout = "namespace"\n'
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\n'
-        'coding = "sonnet"\n'
-    )
-
-    config = load_config(config_path)
-    assert config.targets["claude"].output_layout == "namespace"
-
-
-def test_roles_dir_ignores_agents_dir_when_both_present(tmp_path):
-    config_path = tmp_path / CONFIG_FILENAME
-    config_path.write_text('[project]\nroles_dir = "roles"\nagents_dir = ".agents/roles"\n')
-
-    config = load_config(config_path)
-    assert config.roles_dir == "roles"
-
-
-def test_agents_dir_no_longer_supported(tmp_path):
-    config_path = tmp_path / CONFIG_FILENAME
-    config_path.write_text('[project]\nagents_dir = "roles"\n')
-
-    config = load_config(config_path)
-    assert config.roles_dir == ".agents/roles"
-
-
 def test_resolve_roles_dir_defaults_when_config_absent(tmp_path):
     assert resolve_roles_dir(tmp_path) == tmp_path / ".agents" / "roles"
-
-
-def test_resolve_roles_dir_uses_roles_toml(tmp_path):
-    config_path = tmp_path / CONFIG_FILENAME
-    config_path.write_text('[project]\nroles_dir = "roles"\n')
-
-    assert resolve_roles_dir(tmp_path) == tmp_path / "roles"
 
 
 def test_user_roles_dir_constant_matches_home() -> None:

--- a/tests/test_copilot.py
+++ b/tests/test_copilot.py
@@ -6,7 +6,6 @@ from role_forge.models import AgentDef, ModelConfig, TargetConfig
 COPILOT_CONFIG = TargetConfig(
     name="copilot",
     enabled=True,
-    output_dir=".",
     model_map={},
     capability_map={},
 )

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -6,7 +6,6 @@ from role_forge.models import AgentDef, ModelConfig, TargetConfig
 CURSOR_CONFIG = TargetConfig(
     name="cursor",
     enabled=True,
-    output_dir=".",
     model_map={},
     capability_map={},
 )

--- a/tests/test_model_less_adapters.py
+++ b/tests/test_model_less_adapters.py
@@ -20,7 +20,6 @@ def _config(name: str) -> TargetConfig:
     return TargetConfig(
         name=name,
         enabled=True,
-        output_dir=".",
         model_map={},
         capability_map={},
     )

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -319,27 +319,3 @@ def test_cast_nested_agent_preserves_relative_path(opencode_config):
     adapter = OpenCodeAdapter()
     outputs = adapter.cast([agent], opencode_config)
     assert outputs[0].path == ".opencode/agents/l2/scout.md"
-
-
-def test_cast_namespace_layout_uses_namespaced_task_permissions() -> None:
-    adapter = OpenCodeAdapter()
-    config = TargetConfig(
-        name="opencode",
-        output_layout="namespace",
-        model_map={"reasoning": "model-r", "coding": "model-c"},
-    )
-    agents = [
-        AgentDef(
-            name="orchestrator",
-            description="Orchestrator",
-            role="primary",
-            relative_path="l1/orchestrator.md",
-            capabilities=[{"delegate": ["worker"]}],
-        ),
-        AgentDef(name="worker", description="Worker", relative_path="l3/worker.md"),
-    ]
-
-    outputs = adapter.cast(agents, config)
-    by_path = {output.path: output.content for output in outputs}
-    assert ".opencode/agents/l1__orchestrator.md" in by_path
-    assert '"l3__worker": allow' in by_path[".opencode/agents/l1__orchestrator.md"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -221,7 +221,7 @@ def test_find_roles_dir_ignores_agents_dir_alias(tmp_path):
     agents = tmp_path / "my-agents"
     agents.mkdir()
 
-    with pytest.raises(FileNotFoundError, match=r"Expected 'roles\.toml' with roles_dir"):
+    with pytest.raises(FileNotFoundError, match=r"No agent definitions found"):
         find_roles_dir(tmp_path)
 
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -6,7 +6,7 @@ import importlib.util
 
 import pytest
 
-from role_forge.models import AgentDef, HierarchyConfig, ModelConfig, TargetConfig
+from role_forge.models import AgentDef, HierarchyConfig, ModelConfig
 from role_forge.topology import (
     TopologyError,
     build_output_path,
@@ -150,18 +150,16 @@ def test_validate_output_layout_rejects_flatten_collisions() -> None:
         AgentDef(name="worker", relative_path="l2/worker.md"),
         AgentDef(name="worker", relative_path="l3/worker.md"),
     ]
-    config = TargetConfig(name="claude", output_layout="flatten")
 
     with pytest.raises(TopologyError, match="maps both"):
-        validate_output_layout(agents, config)
+        validate_output_layout(agents, "flatten")
 
 
 def test_build_output_path_rejects_path_escape() -> None:
     agent = AgentDef(name="escape", relative_path="roles/escape.md")
-    config = TargetConfig(name="claude", output_layout="preserve")
 
     with pytest.raises(TopologyError, match="escapes base directory"):
-        build_output_path(agent, base_dir="../outside", suffix=".md", config=config)
+        build_output_path(agent, base_dir="../outside", suffix=".md", layout="preserve")
 
 
 def test_validate_agents_balanced_tree() -> None:

--- a/tests/test_windsurf.py
+++ b/tests/test_windsurf.py
@@ -6,7 +6,6 @@ from role_forge.models import AgentDef, ModelConfig, TargetConfig
 WINDSURF_CONFIG = TargetConfig(
     name="windsurf",
     enabled=True,
-    output_dir=".",
     model_map={},
     capability_map={},
 )


### PR DESCRIPTION
## Summary

- **Claude `name:` fix**: frontmatter `name:` now uses `canonical_id` (e.g. `directors/bug-fix`) instead of raw `name`, and `Task()` refs match. Prevents collisions across namespaces.
- **Render scope fix**: `_render_after_add` now only renders the installed scope instead of merging user+project — no more "Found 1 role → Rendered 10".
- **Remove `output_dir` and `output_layout` from config**: output always goes to project root; layout is adapter-controlled (`namespace` for Claude/Copilot, `preserve` for others). `roles_dir` kept for source repo discovery only.
- **SameFileError fix**: `role-forge add ./` no longer crashes when source and install directories are the same file — the copy is skipped.

## Test plan

- [x] All 193 tests pass
- [x] Lint clean (ruff check + ruff format)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)