### PR TITLE
♻️ refactor(core): remove `role store` workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,12 +25,13 @@ just pre-commit    # 运行 pre-commit 钩子
 
 ```
 src/role_forge/
-├── cli.py          # CLI 入口（add / update / render / list / remove）
+├── cli.py          # CLI 入口（add / update / list / remove）
 ├── config.py       # roles.toml 解析
 ├── loader.py       # Role 定义加载（YAML frontmatter + Markdown）
+├── outputs.py      # 项目级 output ownership manifest
 ├── models.py       # Pydantic 数据模型
 ├── groups.py       # Capability group 和 bash policy 定义
-├── registry.py     # GitHub source 获取和 roles_dir 发现
+├── registry.py     # GitHub source 获取、repo cache 与 roles_dir 发现
 ├── platform.py     # 平台检测
 ├── topology.py     # hierarchy / delegation / output layout 校验
 └── adapters/       # 平台适配器和 entry point 注册
@@ -38,12 +39,13 @@ src/role_forge/
 
 ## 当前 CLI 语义
 
-- 安装作用域支持 project（默认）与 user（`-g`，`~/.agents/roles`）
-- `render` 会合并 project + user roles，并以 project 同 canonical id 覆盖 user
-- `add` / `update` 默认会对覆盖操作做确认；`--yes` 跳过确认与覆盖提示
+- `roles.toml` 是 source repo 内语义配置，`add` / `update` 直接从本地 repo 或 repo cache 解析并生成目标文件
+- 全局 repo cache 位于 `~/.config/role-forge/repos`，索引位于 `~/.config/role-forge/manifest.json`
+- 项目级输出归属记录位于 `.role-forge/outputs.json`，用于 `remove` 精准清理和重建剩余 source 输出
+- `add` / `update` 默认会对覆盖操作做确认；`--yes` 跳过覆盖提示
 - `roles.toml` 只支持 `project.roles_dir`，不再兼容 `project.agents_dir`
-- `list` / `remove` / `doctor` / `clean` 都按单一作用域工作：默认 project，`-g` 为 user
-- 本地路径安装继续使用 copy 语义，不支持 symlink
+- 没有独立 `render` 命令；重新生成由 `add` / `update` 驱动
+- `remove` 以 source 为单位删除 cache 与已生成文件，并重建剩余 source 的冲突输出
 
 ## 添加新适配器
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Canonical role-definition toolkit for coding agents.
 
-`role-forge` keeps one canonical role source and renders it into platform-specific agent formats for tools like Claude Code, OpenCode, Cursor, and Windsurf.
+`role-forge` fetches canonical role sources and generates platform-specific agent files for tools like Claude Code, OpenCode, Cursor, and Windsurf.
 
 ## Install
 
@@ -15,21 +15,18 @@ uv tool install role-forge
 ```bash
 role-forge add PFCCLab/precision-agents -y
 role-forge add ./local-roles
-role-forge render --target claude
+role-forge update PFCCLab/precision-agents -y
 role-forge list
+role-forge list --sources
 ```
 
 `add` and `update` ask before overwriting existing files. Use `--yes` to skip confirmations.
-
-Project installs are the default. Use `role-forge add -g`, `role-forge list -g`, and
-`role-forge remove -g` for the user scope in `~/.agents/roles`. Rendering merges both
-scopes and lets project roles override same-id user roles.
 
 ## Why this repo exists
 
 - avoid maintaining the same role prompt in multiple tool-specific formats
 - keep capabilities, delegation policy, and model tiers in one canonical source
-- validate hierarchy and output layout before rendering
+- validate hierarchy and output layout before generation
 - support extension through adapter entry points
 
 ## Capability model

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -17,12 +17,13 @@ src/role_forge/
 
 ## Module responsibilities
 
-- `cli.py`: user-facing commands such as `add`, `render`, `list`, `remove`, and `update`
-- `config.py`: `roles.toml` loading and roles directory resolution
+- `cli.py`: user-facing commands such as `add`, `list`, `remove`, and `update`
+- `config.py`: `roles.toml` loading, source roles resolution, and project output manifest paths
 - `loader.py`: canonical role loading from Markdown plus YAML frontmatter
+- `outputs.py`: project-local generated-output ownership manifest
 - `models.py`: shared Pydantic models for roles, hierarchy, targets, and outputs
 - `groups.py`: capability-group and bash-policy definitions
-- `registry.py`: source parsing, fetch/update logic, and source-repository role discovery
+- `registry.py`: source parsing, repo-cache fetch/update logic, and source-repository role discovery
 - `platform.py`: target platform detection from project markers
 - `topology.py`: hierarchy, delegation, and output-layout validation
 - `adapters/`: built-in renderers and adapter registry

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -25,11 +25,11 @@ Platform adapters interpret that source into target-specific files without chang
 
 Typical project flow:
 
-1. install or update canonical roles from a GitHub repository or local path
-2. store those roles under `.agents/roles/` or a configured `roles_dir`
-3. resolve target configuration from `roles.toml`
+1. fetch or refresh a canonical role source from a GitHub repository or local path
+2. resolve role definitions from the source repo itself (`roles/` or `project.roles_dir`)
+3. resolve target configuration from the source repo's `roles.toml`, then fall back to adapter defaults or project marker detection
 4. validate hierarchy, delegation, and output layout safety
-5. render platform outputs such as `.claude/agents/*.md`
+5. generate platform outputs such as `.claude/agents/*.md`
 
 ## Design goals
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@ Different coding tools want different agent formats. `role-forge` keeps one cano
 
 ## What it does
 
-- installs reusable role definitions from GitHub repos or local paths
-- stores a canonical source tree in `.agents/roles/`
-- renders that source into Claude Code, OpenCode, Cursor, and Windsurf formats
+- fetches reusable role definitions from GitHub repos or local paths
+- keeps project-authored canonical roles in `roles/` and fetched repos in the global repo cache
+- generates Claude Code, OpenCode, Cursor, and Windsurf files directly from source repos or repo cache
 - validates hierarchy, delegation rules, and output layout collisions before writing files
 - lets third-party adapters extend the render pipeline through entry points
 

--- a/docs/reference/canonical-role-definition.md
+++ b/docs/reference/canonical-role-definition.md
@@ -4,7 +4,7 @@
 
 ## Layout
 
-Store role files under `roles/` in a source repo, or under `.agents/roles/` after installation.
+Store role files under `roles/` in a source repo.
 
 ```text
 roles/

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@
 ## Source format
 
 - **GitHub**: `org/repo` or `org/repo@ref` (branch/tag). Resolved to the repository; `ref` is used for checkout.
-- **Local**: `./path` or `/absolute/path`. Roles are copied from the path; no git.
+- **Local**: `./path` or `/absolute/path`. Roles are read directly from that path; no git.
 
 ## Install
 
@@ -25,61 +25,43 @@ Without `--yes`, `add` and `update` ask before overwriting existing files.
 
 ```bash
 role-forge add ./my-agents
-role-forge add ./my-agents -g
 ```
 
-### Render to a specific target
-
-```bash
-role-forge render --target claude
-```
-
-### List installed roles
+### List generated project sources
 
 ```bash
 role-forge list
-role-forge list -g
 role-forge list --json
 ```
 
-### Check unmanaged files
+### List cached sources
 
 ```bash
-role-forge doctor
-role-forge doctor -g --json
-```
-
-### Clean unmanaged files
-
-```bash
-role-forge clean --dry-run
-role-forge clean -y
+role-forge list --sources
+role-forge list --sources --json
 ```
 
 ### Update a GitHub source
 
 ```bash
 role-forge update PFCCLab/precision-agents
-role-forge update PFCCLab/precision-agents -g -y
+role-forge update PFCCLab/precision-agents -y
 ```
 
-### Remove a role
+### Remove a source and its generated outputs
 
 ```bash
-role-forge remove explorer
-role-forge remove l2/worker
+role-forge remove PFCCLab/precision-agents --yes
+role-forge remove /absolute/path/to/local-roles --yes
 ```
 
 ## Command model
 
-- `add` fetches a source, validates role topology, installs canonical files, and auto-renders when targets are explicit or detectable
-- `add` is interactive by default; `--yes` skips install and overwrite prompts
-- `render` regenerates target outputs from merged canonical roles, with project scope overriding user scope
-- `list` shows installed roles for one scope at a time; use `-g` for user scope and `--json` for machine-readable output
-- `remove` deletes the canonical file from one scope; target outputs can then be regenerated with `render`
-- `doctor` reports unmanaged files in the selected roles directory
-- `clean` removes unmanaged files from the selected roles directory
-- `update` reuses the `add` flow for non-local sources and also supports `-g`
+- `add` fetches a source, validates role topology, chooses targets, and generates output files directly
+- `update` refreshes a GitHub source and regenerates the same targets and role selection unless overridden
+- `list` shows project-generated sources by default; use `--sources` to inspect the global repo cache index
+- `remove` deletes a source's generated files, removes cached remote repos, and rebuilds remaining recorded sources to restore collisions
+- there is no standalone `render` command; regeneration flows through `add` and `update`
 
 ## Target detection
 
@@ -92,7 +74,7 @@ When `--target` is omitted, `role-forge` detects supported tools from project ma
 
 ## Behavior notes
 
-- **Overwrite**: Without `--yes`, `add` and `update` prompt before overwriting existing roles.
+- **Overwrite**: Without `--yes`, `add` and `update` prompt before overwriting existing output files.
 - **Update**: Only non-local sources can be updated; local paths must be re-added.
-- **Remove**: Deletes the canonical role file only; run `render` to regenerate target outputs or clean up platform dirs.
-- **Scope**: Project scope uses `roles_dir` from `roles.toml` (default `.agents/roles/`); user scope uses `~/.agents/roles/` (see configuration).
+- **Source config**: `roles.toml` is read from the source repo itself; target resolution falls back to adapter defaults or project marker detection when needed.
+- **State files**: project output ownership is tracked in `.role-forge/outputs.json`; cached remote repos are indexed in `~/.config/role-forge/manifest.json`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -6,7 +6,7 @@ Project configuration lives in `roles.toml`.
 
 ```toml
 [project]
-roles_dir = ".agents/roles"
+roles_dir = "roles"
 
 [targets.claude]
 
@@ -19,24 +19,17 @@ coding = "claude-sonnet-4"
 
 - `roles_dir`: role definitions directory in the **source** repository (used by `find_roles_dir` during `add`)
 
-## Install scopes
+## Runtime state
 
-- project scope is the default install target, always `.agents/roles`
-- user scope uses `~/.agents/roles` and is selected with `-g` or `--global`
-- render operates on the installed scope; `add` only renders roles from the scope that was just installed
-- list and remove operate on one scope at a time: default project, `-g` for user
+- fetched GitHub repos are cached under `~/.config/role-forge/repos`
+- the global cache index lives at `~/.config/role-forge/manifest.json`
+- per-project generated-output ownership lives at `.role-forge/outputs.json`
+- no role store is maintained; outputs are generated directly from the source repo or repo cache
 
 ## Local sources
 
 - local installs use `role-forge add ./path` or `role-forge add /absolute/path`
-- local sources are copied into the selected install scope; symlink installs are not supported
-- if source and destination are the same file, the copy is skipped
-
-## Hygiene commands
-
-- `doctor` reports unmanaged files in the selected roles directory
-- unmanaged files are non-`.md` files or `.md` files that fail role parsing
-- `clean` removes unmanaged files and supports `--dry-run`, `-y`, and `-g`
+- local sources are read directly from disk and are not copied into a separate store
 
 ## Target keys
 
@@ -49,8 +42,7 @@ coding = "claude-sonnet-4"
 When reading a source repository, `role-forge` resolves role files in this order:
 
 1. `roles.toml` with `project.roles_dir`
-2. `.agents/roles/` directory
-3. fallback `roles/`
+2. fallback `roles/`
 
 ## Output layout
 

--- a/src/role_forge/cli.py
+++ b/src/role_forge/cli.py
@@ -6,32 +6,32 @@ import json
 import shutil
 import subprocess
 import sys
+from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 import typer
 from loguru import logger
 
 from role_forge import __version__
-from role_forge.adapters import list_adapters
 
-# Default: only WARNING and above so INFO/DEBUG are hidden unless configured elsewhere.
 logger.remove()
 logger.add(sys.stderr, level="WARNING")
 
 app = typer.Typer(
-    help=("role-forge: install canonical role definitions and render them across coding tools.")
+    help=("role-forge: fetch canonical role sources and generate platform-specific agent files.")
 )
-
-Scope = Literal["project", "user"]
 
 
 @dataclass(frozen=True)
-class InstallPlan:
-    install_dir: Path
-    new_agents: list[Any]
-    overwrite_agents: list[Any]
+class SourceBundle:
+    source_key: str
+    source_ref: str
+    parsed: Any
+    repo_path: Path
+    config: Any | None
+    agents: list[Any]
 
 
 def _version_callback(value: bool) -> None:
@@ -47,7 +47,7 @@ def main(
         typer.Option("--version", callback=_version_callback, is_eager=True, help="Show version"),
     ] = None,
 ) -> None:
-    """role-forge: install canonical role definitions and render them across tools."""
+    """role-forge: fetch canonical role sources and generate platform-specific agent files."""
 
 
 def _style(text: str, *, fg: str | None = None, bold: bool = False) -> str:
@@ -67,7 +67,6 @@ def _warn(message: str) -> None:
 
 
 def _error(message: str) -> None:
-    # Errors are printed to stdout so that Typer's CliRunner (and users) can always see them.
     typer.echo(_style(message, fg=typer.colors.RED, bold=True))
 
 
@@ -81,208 +80,8 @@ def _bullet(label: str, value: str = "") -> str:
     return f"  {_style('•', fg=typer.colors.BLUE)} {label}"
 
 
-def _resolve_target_config(
-    target_name: str,
-    adapter,
-    project: Path,
-    interactive: bool = True,
-    source_project: Path | None = None,
-):
-    """TargetConfig: source repo toml > project toml > adapter defaults. No model prompt."""
-    from role_forge.config import find_config, load_config
-    from role_forge.models import TargetConfig
-
-    def _accept_config(cfg: TargetConfig) -> TargetConfig | None:
-        if adapter.requires_model_map and not cfg.model_map:
-            return None
-        return cfg
-
-    # Prefer source repo roles.toml when rendering after add/update
-    if source_project is not None:
-        src_config_path = find_config(source_project)
-        if src_config_path is not None:
-            src_config = load_config(src_config_path)
-            if target_name in src_config.targets:
-                cfg = src_config.targets[target_name]
-                accepted = _accept_config(cfg)
-                if accepted is not None:
-                    return accepted
-
-    config_path = find_config(project)
-    if config_path is not None:
-        project_config = load_config(config_path)
-        if target_name in project_config.targets:
-            cfg = project_config.targets[target_name]
-            accepted = _accept_config(cfg)
-            if accepted is not None:
-                return accepted
-
-    if adapter.default_model_map:
-        return TargetConfig(
-            name=target_name,
-            enabled=True,
-            model_map=adapter.default_model_map,
-        )
-
-    if not adapter.requires_model_map:
-        return TargetConfig(name=target_name, enabled=True)
-
-    _error(
-        f"No model_map for '{target_name}'. Add [targets.{target_name}.model_map] to roles.toml "
-        f"(in the source repo or current project)."
-    )
-    raise typer.Exit(1)
-
-
 def _resolve_project(project_dir: str | None) -> Path:
     return Path(project_dir).resolve() if project_dir else Path.cwd()
-
-
-def _resolve_roles_dir(project: Path) -> Path:
-    from role_forge.config import resolve_roles_dir
-
-    return resolve_roles_dir(project)
-
-
-def _resolve_scope(global_scope: bool) -> Scope:
-    return "user" if global_scope else "project"
-
-
-def _prompt_scope(prompt: str = "Install to (p)roject or (g)lobal?") -> Scope:
-    """Interactively ask for project vs user (global) scope. Default project."""
-    raw = typer.prompt(prompt, default="p").strip().lower()
-    if raw in ("g", "global"):
-        return "user"
-    return "project"
-
-
-def _scope_label(scope: Scope) -> str:
-    return "user" if scope == "user" else "project"
-
-
-def _roles_not_found_message(scope: Scope, roles_dir: Path) -> str:
-    return f"No roles found in {_scope_label(scope)} scope: {roles_dir}"
-
-
-def _load_agents_in_scope(project: Path, scope: Scope):
-    from role_forge.loader import load_agents_in_scope
-
-    try:
-        roles_dir, agents = load_agents_in_scope(project, scope=scope)
-    except Exception as exc:
-        _error(str(exc))
-        raise typer.Exit(1) from exc
-    if agents:
-        return roles_dir, agents
-
-    _error(_roles_not_found_message(scope, roles_dir))
-    raise typer.Exit(1)
-
-
-def _load_merged_agents(project: Path):
-    from role_forge.loader import load_merged_agents
-
-    try:
-        agents = load_merged_agents(project)
-    except Exception as exc:
-        _error(str(exc))
-        raise typer.Exit(1) from exc
-    if agents:
-        return agents
-
-    _error("No roles found in project or user scope. Run 'role-forge add' first.")
-    raise typer.Exit(1)
-
-
-def _serialize_agent(agent, *, scope: Scope) -> dict[str, Any]:
-    return {
-        "name": agent.name,
-        "canonical_id": agent.canonical_id,
-        "role": agent.role,
-        "tier": agent.model.tier,
-        "temperature": agent.model.temperature,
-        "relative_path": agent.relative_path,
-        "source_path": str(agent.source_path) if agent.source_path else None,
-        "scope": scope,
-    }
-
-
-def _scan_unmanaged_files(project: Path, scope: Scope):
-    from role_forge.config import USER_ROLES_DIR
-    from role_forge.loader import find_unmanaged_files
-
-    roles_dir = USER_ROLES_DIR if scope == "user" else _resolve_roles_dir(project)
-    return roles_dir, find_unmanaged_files(roles_dir)
-
-
-def _render_agents_to_targets(
-    project: Path,
-    agents,
-    target_names: list[str],
-    *,
-    interactive: bool = True,
-    source_project: Path | None = None,
-) -> None:
-    from role_forge.adapters import get_adapter
-    from role_forge.topology import TopologyError
-
-    for target_name in target_names:
-        try:
-            adapter = get_adapter(target_name)
-        except ValueError as e:
-            _error(str(e))
-            continue
-
-        config = _resolve_target_config(
-            target_name, adapter, project, interactive=interactive, source_project=source_project
-        )
-
-        try:
-            outputs = adapter.cast(agents, config)
-        except TopologyError as e:
-            _error(str(e))
-            raise typer.Exit(1) from e
-
-        outputs_to_write = _confirm_render_overwrite(project, outputs, interactive)
-        if outputs_to_write:
-            _write_outputs(project, outputs_to_write)
-        _success(f"Rendered {len(outputs)} roles -> {target_name}")
-
-
-def _confirm_render_overwrite(project: Path, outputs, interactive: bool):
-    """If interactive and some paths exist, prompt once. Return list to write (filtered or all)."""
-    existing = [o for o in outputs if (project / o.path).exists()]
-    if not existing or not interactive:
-        return list(outputs)
-    n = len(existing)
-    if not typer.confirm(f"Overwrite {n} existing file(s) in {project}?", default=True):
-        existing_paths = {(project / o.path).resolve() for o in existing}
-        return [o for o in outputs if (project / o.path).resolve() not in existing_paths]
-    return list(outputs)
-
-
-def _write_outputs(project: Path, outputs) -> None:
-    for out in outputs:
-        full_path = (project / out.path).resolve()
-        full_path.parent.mkdir(parents=True, exist_ok=True)
-        full_path.write_text(out.content, encoding="utf-8")
-
-
-def _resolve_remove_target(agents, ref: str):
-    by_id = {agent.canonical_id: agent for agent in agents}
-    if ref in by_id:
-        return by_id[ref]
-
-    matches = [agent for agent in agents if agent.name == ref]
-    if len(matches) == 1:
-        return matches[0]
-    if len(matches) > 1:
-        choices = ", ".join(agent.canonical_id for agent in matches)
-        _error(f"Ambiguous agent name '{ref}'. Use one of: {choices}")
-        raise typer.Exit(1)
-
-    _error(f"Agent not found: {ref}")
-    raise typer.Exit(1)
 
 
 def _format_source_error(exc: Exception, source: str) -> str:
@@ -303,520 +102,530 @@ def _format_roles_dir_error(source: str, repo_path: Path) -> str:
     )
 
 
-def _filter_agents_by_role(agents, role_patterns: list[str] | None):
-    """Keep agents whose name or canonical_id matches any pattern (substring, case-insensitive)."""
+def _normalize_source_ref(parsed) -> str:
+    if parsed.is_local:
+        return str(Path(parsed.local_path).resolve())
+    return parsed.cache_key
+
+
+def _filter_agents_by_role_patterns(agents, role_patterns: list[str] | None):
     if not role_patterns:
         return list(agents)
-    lower_patterns = [p.lower() for p in role_patterns]
+    lower_patterns = [pattern.lower() for pattern in role_patterns]
     return [
-        a
-        for a in agents
-        if any(pat in a.name.lower() or pat in a.canonical_id.lower() for pat in lower_patterns)
+        agent
+        for agent in agents
+        if any(
+            pattern in agent.name.lower() or pattern in agent.canonical_id.lower()
+            for pattern in lower_patterns
+        )
     ]
+
+
+def _filter_agents_by_ids(agents, selected_role_ids: list[str]):
+    wanted = set(selected_role_ids)
+    filtered = [agent for agent in agents if agent.canonical_id in wanted]
+    missing = sorted(wanted - {agent.canonical_id for agent in filtered})
+    if missing:
+        _error(f"Stored role selection no longer exists in source: {', '.join(missing)}")
+        raise typer.Exit(1)
+    return filtered
 
 
 def _show_agent_table(agents) -> None:
     _info(f"Found {len(agents)} role(s):")
     for agent in agents:
-        logger.info(
-            _bullet(
-                agent.canonical_id,
-                f"role={agent.role}, tier={agent.model.tier}",
-            )
-        )
+        logger.info(_bullet(agent.canonical_id, f"role={agent.role}, tier={agent.model.tier}"))
 
 
-def _build_install_plan(install_dir: Path, agents) -> InstallPlan:
-    new_agents = []
-    overwrite_agents = []
-    for agent in agents:
-        destination = install_dir / agent.install_relative_path()
-        if destination.exists():
-            overwrite_agents.append(agent)
-        else:
-            new_agents.append(agent)
-    return InstallPlan(
-        install_dir=install_dir, new_agents=new_agents, overwrite_agents=overwrite_agents
-    )
-
-
-def _confirm_install(plan: InstallPlan, scope: Scope, yes: bool) -> bool:
-    """Return True to include overwrites, False to install only new. Raises Exit on cancel."""
-    _info("Install plan")
-    logger.info(_bullet("target", str(plan.install_dir)))
-    logger.info(_bullet("scope", _scope_label(scope)))
-    logger.info(_bullet("new", str(len(plan.new_agents))))
-    logger.info(_bullet("overwrite", str(len(plan.overwrite_agents))))
-
-    if yes:
-        return True
-    if not plan.overwrite_agents:
-        return True
-    n = len(plan.overwrite_agents)
-    if not typer.confirm(f"Overwrite {n} existing role(s)?", default=True):
-        _warn("Skipping overwrites; only new roles will be installed.")
-        return False
-    return True
-
-
-def _copy_agents(plan: InstallPlan, yes: bool, include_overwrites: bool) -> list[Any]:
-    agents_to_copy = plan.new_agents + (plan.overwrite_agents if include_overwrites else [])
-    installed = []
-    for agent in agents_to_copy:
-        assert agent.source_path is not None
-        destination = plan.install_dir / agent.install_relative_path()
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if destination.resolve() == agent.source_path.resolve():
-            installed.append(agent)
-            logger.info(_bullet("skipped (same file)", agent.canonical_id))
-            continue
-        shutil.copy2(agent.source_path, destination)
-        installed.append(agent)
-        logger.info(_bullet("installed", agent.canonical_id))
-    return installed
-
-
-def _resolve_render_targets(
-    project: Path,
-    target: list[str] | None,
-    source_default_targets: list[str] | None,
-) -> list[str]:
-    """Resolve render targets in priority order:
-
-    1. Explicit --target
-    2. Targets from the source repo's roles.toml (if any)
-    3. Fallback: current project roles.toml / auto-detected platforms
-    """
-    from role_forge.platform import resolve_targets
-
-    if target:
-        return list(target)
-    if source_default_targets:
-        return list(source_default_targets)
-    return resolve_targets(project)
-
-
-def _render_after_add(
-    project: Path,
-    target: list[str] | None,
-    source_default_targets: list[str] | None,
-    interactive: bool,
-    no_render: bool,
-    source_project: Path | None = None,
-    global_install: bool = False,
-) -> None:
-    """Render after add/update; toml default. Use --no-render to skip or confirm if interactive."""
-    if no_render:
-        return
-    default_targets = _resolve_render_targets(project, target, source_default_targets)
-    if not default_targets:
-        _info("Installed canonical roles. No render target detected in this project.")
-        return
-    if interactive and not typer.confirm(
-        f"Render to {', '.join(default_targets)}?",
-        default=True,
-    ):
-        _info("Skipped rendering. Run 'role-forge render' when needed.")
-        return
-    # Global install: render into home so ~/.opencode/agents etc. are populated
-    render_root = Path.home() if global_install else project
-    scope: Scope = "user" if global_install else "project"
-    from role_forge.loader import load_agents_in_scope
-
-    _, agents = load_agents_in_scope(render_root, scope=scope)
-    if not agents:
-        _warn("No roles to render in installed scope.")
-        return
-    _render_agents_to_targets(
-        render_root,
-        agents,
-        default_targets,
-        interactive=interactive,
-        source_project=source_project,
-    )
-
-
-@app.command()
-def add(
-    source: Annotated[str, typer.Argument(help="Source: org/repo[@ref] or local path")],
-    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip all prompts")] = False,
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="Install to ~/.agents/roles/")
-    ] = False,
-    target: Annotated[
-        list[str] | None,
-        typer.Option("--target", "-t", help="Render to these targets (default: toml or auto)"),
-    ] = None,
-    no_render: Annotated[
-        bool,
-        typer.Option("--no-render", help="Skip render after install"),
-    ] = False,
-    role: Annotated[
-        list[str] | None,
-        typer.Option("--role", "-r", help="Install only roles matching (substring of name/id)"),
-    ] = None,
-    project_dir: Annotated[
-        str | None, typer.Option("--project-dir", help="Project root directory")
-    ] = None,
-) -> None:
-    """Add agent definitions from a source. Renders to targets by default (toml or -t)."""
-    from role_forge.config import USER_ROLES_DIR, find_config, load_config
+def _load_source_bundle(
+    source: str,
+    *,
+    role_patterns: list[str] | None = None,
+    selected_role_ids: list[str] | None = None,
+    fetch: bool = True,
+) -> SourceBundle:
+    from role_forge.config import find_config, load_config
     from role_forge.loader import load_agents
-    from role_forge.registry import fetch_source, find_roles_dir, parse_source
+    from role_forge.manifest import source_entry
+    from role_forge.registry import (
+        cache_path_for_source,
+        fetch_source,
+        find_roles_dir,
+        parse_source,
+    )
     from role_forge.topology import TopologyError, validate_agents
 
     parsed = parse_source(source)
-    try:
-        repo_path = fetch_source(parsed)
-    except Exception as e:
-        _error(_format_source_error(e, source))
-        raise typer.Exit(1) from e
+    if fetch:
+        try:
+            repo_path = fetch_source(parsed)
+        except Exception as exc:
+            _error(_format_source_error(exc, source))
+            raise typer.Exit(1) from exc
+    elif parsed.is_local:
+        repo_path = Path(source).resolve()
+    else:
+        cache = source_entry(parsed.cache_key)
+        repo_path = (
+            Path(cache["cache_path"])
+            if cache is not None and "cache_path" in cache
+            else cache_path_for_source(parsed)
+        )
+        if not repo_path.is_dir():
+            _error(f"Cached source not found: {parsed.cache_key}")
+            raise typer.Exit(1)
 
     try:
         roles_dir = find_roles_dir(repo_path)
-    except FileNotFoundError as e:
+    except FileNotFoundError as exc:
         _error(_format_roles_dir_error(source, repo_path))
-        raise typer.Exit(1) from e
+        raise typer.Exit(1) from exc
 
-    # Resolve default targets from the source repo's roles.toml (if present)
-    source_default_targets: list[str] | None = None
     config_path = find_config(repo_path)
-    if config_path is not None:
-        project_config = load_config(config_path)
-        enabled_targets = [name for name, cfg in project_config.targets.items() if cfg.enabled]
-        if enabled_targets:
-            source_default_targets = enabled_targets
+    source_config = load_config(config_path) if config_path is not None else None
 
     try:
         agents = load_agents(roles_dir, strict=True)
-    except Exception as e:
-        _error(str(e))
-        raise typer.Exit(1) from e
+    except Exception as exc:
+        _error(str(exc))
+        raise typer.Exit(1) from exc
     if not agents:
         _error("No role definitions found in source.")
         raise typer.Exit(1)
 
     try:
         validate_agents(agents)
-    except TopologyError as e:
-        _error(str(e))
-        raise typer.Exit(1) from e
+    except TopologyError as exc:
+        _error(str(exc))
+        raise typer.Exit(1) from exc
 
-    agents = _filter_agents_by_role(agents, role)
+    if role_patterns is not None:
+        agents = _filter_agents_by_role_patterns(agents, role_patterns)
+    elif selected_role_ids is not None:
+        agents = _filter_agents_by_ids(agents, selected_role_ids)
+
     if not agents:
-        _error("No roles match the given --role filter.")
+        _error("No roles match the requested selection.")
         raise typer.Exit(1)
 
-    _show_agent_table(agents)
+    return SourceBundle(
+        source_key=_normalize_source_ref(parsed),
+        source_ref=_normalize_source_ref(parsed),
+        parsed=parsed,
+        repo_path=repo_path,
+        config=source_config,
+        agents=agents,
+    )
 
-    project = _resolve_project(project_dir)
-    if yes:
-        scope = _resolve_scope(global_install)
-    elif global_install:
-        scope = "user"
-    else:
-        scope = _prompt_scope()
-        global_install = scope == "user"
-    install_dir = USER_ROLES_DIR if global_install else _resolve_roles_dir(project)
-    install_dir.mkdir(parents=True, exist_ok=True)
 
-    plan = _build_install_plan(install_dir, agents)
-    include_overwrites = _confirm_install(plan, scope, yes)
-    if not include_overwrites and not plan.new_agents:
-        _warn("Install cancelled.")
-        raise typer.Exit(1)
+def _resolve_target_config(target_name: str, adapter, source_config):
+    from role_forge.models import TargetConfig
 
-    # Prune orphaned files when doing full update from remote (agent removed upstream)
-    # Skip prune when --role filter is used (partial update)
-    if not parsed.is_local and role is None:
-        from role_forge.manifest import prune_orphaned, update_manifest_for_source
+    def _accept(cfg: TargetConfig) -> TargetConfig | None:
+        if adapter.requires_model_map and not cfg.model_map:
+            return None
+        return cfg
 
-        current_paths = {a.install_relative_path() for a in agents}
-        pruned = prune_orphaned(install_dir, parsed.cache_key, current_paths)
-        for p in pruned:
-            logger.info(_bullet("pruned", str(p.relative_to(install_dir))))
+    if source_config is not None and target_name in source_config.targets:
+        accepted = _accept(source_config.targets[target_name])
+        if accepted is not None:
+            return accepted
 
-    installed_agents = _copy_agents(plan, yes, include_overwrites)
+    if adapter.default_model_map:
+        return TargetConfig(name=target_name, enabled=True, model_map=adapter.default_model_map)
 
-    # Update manifest for remote sources so future updates can prune correctly
-    if not parsed.is_local:
-        from role_forge.manifest import update_manifest_for_source
+    if not adapter.requires_model_map:
+        return TargetConfig(name=target_name, enabled=True)
 
-        # Merge with existing manifest when --role filter used (partial update)
-        if role is not None:
-            from role_forge.manifest import load_manifest, paths_for_source
+    _error(
+        f"No model_map for '{target_name}' in the source repo. "
+        f"Add [targets.{target_name}.model_map] to roles.toml."
+    )
+    raise typer.Exit(1)
 
-            existing = set(paths_for_source(load_manifest(install_dir), parsed.cache_key))
-            new_paths = existing | {a.install_relative_path() for a in agents}
-            update_manifest_for_source(install_dir, parsed.cache_key, sorted(new_paths))
-        else:
-            update_manifest_for_source(
-                install_dir, parsed.cache_key, [a.install_relative_path() for a in agents]
-            )
 
-    if not installed_agents:
-        _warn("No roles were installed.")
+def _source_default_targets(source_config) -> list[str]:
+    if source_config is None:
+        return []
+    return [name for name, cfg in source_config.targets.items() if cfg.enabled]
+
+
+def _resolve_target_names(
+    project: Path,
+    *,
+    explicit_targets: list[str] | None,
+    previous_entry: dict[str, Any] | None,
+    source_config,
+) -> list[str]:
+    from role_forge.platform import resolve_targets
+
+    if explicit_targets:
+        return list(explicit_targets)
+    if previous_entry is not None:
+        previous_targets = list(previous_entry.get("targets", {}))
+        if previous_targets:
+            return previous_targets
+    source_targets = _source_default_targets(source_config)
+    if source_targets:
+        return source_targets
+    return resolve_targets(project)
+
+
+def _confirm_target_overwrite(project: Path, target_name: str, outputs, interactive: bool):
+    existing = [output for output in outputs if (project / output.path).exists()]
+    if not existing or not interactive:
+        return list(outputs)
+
+    if not typer.confirm(
+        f"Overwrite {len(existing)} existing file(s) for {target_name} in {project}?",
+        default=True,
+    ):
+        _warn(f"Skipped {target_name}.")
+        return None
+
+    return list(outputs)
+
+
+def _write_outputs(project: Path, outputs) -> list[str]:
+    written_paths: list[str] = []
+    for output in outputs:
+        full_path = (project / output.path).resolve()
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(output.content, encoding="utf-8")
+        written_paths.append(output.path)
+    return written_paths
+
+
+def _render_source(
+    project: Path,
+    bundle: SourceBundle,
+    target_names: list[str],
+    *,
+    interactive: bool,
+) -> dict[str, dict[str, list[str]]]:
+    from role_forge.adapters import get_adapter
+    from role_forge.topology import TopologyError
+
+    target_outputs: dict[str, dict[str, list[str]]] = {}
+    selected_roles = [agent.canonical_id for agent in bundle.agents]
+
+    for target_name in target_names:
+        try:
+            adapter = get_adapter(target_name)
+        except ValueError as exc:
+            _error(str(exc))
+            raise typer.Exit(1) from exc
+
+        config = _resolve_target_config(target_name, adapter, bundle.config)
+        try:
+            outputs = adapter.cast(bundle.agents, config)
+        except TopologyError as exc:
+            _error(str(exc))
+            raise typer.Exit(1) from exc
+
+        confirmed_outputs = _confirm_target_overwrite(project, target_name, outputs, interactive)
+        if confirmed_outputs is None:
+            continue
+
+        written_paths = _write_outputs(project, confirmed_outputs)
+        target_outputs[target_name] = {
+            "selected_roles": list(selected_roles),
+            "files": written_paths,
+        }
+        _success(f"Generated {len(written_paths)} file(s) -> {target_name}")
+
+    return target_outputs
+
+
+def _record_cached_source(bundle: SourceBundle) -> None:
+    from role_forge.manifest import update_source
+    from role_forge.registry import read_head_commit
+
+    if bundle.parsed.is_local:
         return
 
-    _success(f"Installed {len(installed_agents)} role(s)")
-    logger.info(_bullet("location", str(install_dir)))
-    _render_after_add(
-        project,
-        target,
-        source_default_targets,
-        interactive=not yes,
-        no_render=no_render,
-        source_project=repo_path,
-        global_install=global_install,
+    update_source(
+        bundle.source_key,
+        cache_key=bundle.parsed.cache_key,
+        cache_path=bundle.repo_path,
+        last_fetched_commit=read_head_commit(bundle.repo_path),
     )
+
+
+def _cached_sources_payload() -> list[dict[str, str]]:
+    from role_forge.manifest import load_manifest
+
+    manifest = load_manifest()
+    return [{"source_key": source_key, **entry} for source_key, entry in manifest.items()]
+
+
+def _project_outputs_payload(project: Path) -> list[dict[str, Any]]:
+    from role_forge.outputs import load_output_manifest
+
+    entries = load_output_manifest(project)
+    payload: list[dict[str, Any]] = []
+    for source_key, entry in entries.items():
+        targets = entry.get("targets", {})
+        role_ids = sorted(
+            {role for target in targets.values() for role in target.get("selected_roles", [])}
+        )
+        files = sorted({path for target in targets.values() for path in target.get("files", [])})
+        payload.append(
+            {
+                "source_key": source_key,
+                "source": entry["source"],
+                "targets": sorted(targets),
+                "role_ids": role_ids,
+                "file_count": len(files),
+                "files": files,
+            }
+        )
+    return payload
+
+
+def _delete_cached_source(source_key: str) -> None:
+    from role_forge.manifest import remove_source, source_entry
+
+    entry = source_entry(source_key)
+    if entry is None:
+        return
+
+    cache_path = entry.get("cache_path")
+    if cache_path:
+        path = Path(cache_path)
+        if path.is_dir():
+            shutil.rmtree(path)
+    remove_source(source_key)
+
+
+def _rebuild_remaining_outputs(project: Path, entries: OrderedDict[str, dict[str, Any]]) -> None:
+    from role_forge.outputs import save_output_manifest, update_source_outputs
+
+    save_output_manifest(project, OrderedDict())
+    for source_key, entry in entries.items():
+        source_ref = entry["source"]
+        target_selections = entry.get("targets", {})
+        rebuilt_targets: dict[str, dict[str, list[str]]] = {}
+        for target_name, target_entry in target_selections.items():
+            selected_roles = target_entry.get("selected_roles", [])
+            bundle = _load_source_bundle(
+                source_ref,
+                selected_role_ids=selected_roles,
+                fetch=False,
+            )
+            rendered = _render_source(project, bundle, [target_name], interactive=False)
+            if target_name in rendered:
+                rebuilt_targets[target_name] = rendered[target_name]
+        if rebuilt_targets:
+            update_source_outputs(
+                project,
+                source_key=source_key,
+                source=source_ref,
+                targets=rebuilt_targets,
+            )
+
+
+@app.command()
+def add(
+    source: Annotated[str, typer.Argument(help="Source: org/repo[@ref] or local path")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip overwrite prompts")] = False,
+    target: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--target", "-t", help="Generate these targets (default: source config or auto)"
+        ),
+    ] = None,
+    role: Annotated[
+        list[str] | None,
+        typer.Option("--role", "-r", help="Generate only roles matching (substring of name/id)"),
+    ] = None,
+    project_dir: Annotated[
+        str | None, typer.Option("--project-dir", help="Project root directory")
+    ] = None,
+) -> None:
+    """Fetch a source and generate project outputs."""
+    from role_forge.outputs import load_output_manifest, update_source_outputs
+    from role_forge.registry import parse_source
+
+    project = _resolve_project(project_dir)
+    parsed = parse_source(source)
+    previous_entry = load_output_manifest(project).get(_normalize_source_ref(parsed))
+
+    selected_role_ids = None
+    if role is None and previous_entry is not None:
+        previous_roles = {
+            role_id
+            for target_entry in previous_entry.get("targets", {}).values()
+            for role_id in target_entry.get("selected_roles", [])
+        }
+        if previous_roles:
+            selected_role_ids = sorted(previous_roles)
+
+    bundle = _load_source_bundle(source, role_patterns=role, selected_role_ids=selected_role_ids)
+    _show_agent_table(bundle.agents)
+    _record_cached_source(bundle)
+
+    target_names = _resolve_target_names(
+        project,
+        explicit_targets=target,
+        previous_entry=previous_entry,
+        source_config=bundle.config,
+    )
+    if not target_names:
+        _success("Source fetched and validated. No target detected, so no files were generated.")
+        _info(f"Use `role-forge add {source} --target <name>` to generate outputs later.")
+        return
+
+    target_outputs = _render_source(project, bundle, target_names, interactive=not yes)
+    if not target_outputs:
+        _warn("No files were generated.")
+        return
+
+    update_source_outputs(
+        project,
+        source_key=bundle.source_key,
+        source=bundle.source_ref,
+        targets=target_outputs,
+    )
+    _success(f"Updated source {bundle.source_key}")
 
 
 @app.command("list")
 def list_agents(
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="List roles from ~/.agents/roles/")
+    sources: Annotated[
+        bool,
+        typer.Option("--sources", help="List cached sources instead of project-generated outputs"),
     ] = False,
-    json_output: Annotated[bool, typer.Option("--json", help="Output roles as JSON")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     project_dir: Annotated[
         str | None, typer.Option("--project-dir", help="Project root directory")
     ] = None,
 ) -> None:
-    """List installed agent definitions for one scope."""
-    from role_forge.loader import load_agents_in_scope
-
+    """List cached sources or project-generated outputs."""
     project = _resolve_project(project_dir)
-    scope = _resolve_scope(global_install)
-    try:
-        roles_dir, agents = load_agents_in_scope(project, scope=scope)
-    except Exception as exc:
-        _error(str(exc))
-        raise typer.Exit(1) from exc
 
-    if json_output:
-        typer.echo(json.dumps([_serialize_agent(agent, scope=scope) for agent in agents], indent=2))
+    if sources:
+        payload = _cached_sources_payload()
+        if json_output:
+            typer.echo(json.dumps(payload, indent=2))
+            return
+        if not payload:
+            _error("No cached sources found.")
+            raise typer.Exit(1)
+
+        _info("Cached sources")
+        typer.echo(f"{'SOURCE':<35} {'COMMIT':<12} {'CACHE PATH'}")
+        typer.echo(_dim("-" * 90))
+        for entry in payload:
+            typer.echo(
+                f"{entry['source_key']:<35} "
+                f"{entry.get('last_fetched_commit', '-')[:12]:<12} "
+                f"{entry.get('cache_path', '-')}"
+            )
+        _success(f"{len(payload)} cached source(s)")
         return
 
-    if not agents:
-        _error(_roles_not_found_message(scope, roles_dir))
+    payload = _project_outputs_payload(project)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2))
+        return
+    if not payload:
+        _error("No generated sources recorded in this project.")
         raise typer.Exit(1)
 
-    _info(f"Roles in {_scope_label(scope)} scope")
-    typer.echo(_dim(f"  {roles_dir}"))
-    typer.echo(f"{'AGENT':<25} {'ID':<25} {'ROLE':<10} {'TIER':<12} {'TEMP':<6}")
-    typer.echo(_dim("-" * 82))
-    for agent in agents:
-        temp = str(agent.model.temperature) if agent.model.temperature is not None else "-"
+    _info("Project-generated sources")
+    typer.echo(f"{'SOURCE':<35} {'TARGETS':<20} {'ROLES':<6} {'FILES':<6}")
+    typer.echo(_dim("-" * 78))
+    for entry in payload:
         typer.echo(
-            f"{agent.name:<25} {agent.canonical_id:<25} {agent.role:<10} "
-            f"{agent.model.tier:<12} {temp:<6}"
+            f"{entry['source_key']:<35} "
+            f"{', '.join(entry['targets']):<20} "
+            f"{len(entry['role_ids']):<6} "
+            f"{entry['file_count']:<6}"
         )
-
-    _success(f"{len(agents)} role(s) found in {_scope_label(scope)} scope")
-
-
-def _render_command(
-    target: list[str] | None,
-    project_dir: str | None,
-    role: list[str] | None = None,
-    yes: bool = False,
-) -> None:
-    """Render installed roles to platform configs; optional --role filter (per-role)."""
-    from role_forge.platform import resolve_targets
-    from role_forge.topology import TopologyError, validate_agents
-
-    project = _resolve_project(project_dir)
-    agents = _load_merged_agents(project)
-    agents = _filter_agents_by_role(agents, role)
-    if not agents:
-        _error("No roles to render (empty or no match for --role).")
-        raise typer.Exit(1)
-    try:
-        validate_agents(agents)
-    except TopologyError as e:
-        _error(str(e))
-        raise typer.Exit(1) from e
-
-    cast_targets = list(target) if target else resolve_targets(project)
-    if not cast_targets:
-        _error(
-            "No render targets detected in this project.\n"
-            f"  available: {', '.join(list_adapters())}\n"
-            "  next step: rerun with `--target <name>`"
-        )
-        raise typer.Exit(1)
-
-    _render_agents_to_targets(project, agents, cast_targets, interactive=not yes)
-
-
-@app.command()
-def render(
-    target: Annotated[
-        list[str] | None, typer.Option("--target", "-t", help="Target platform(s)")
-    ] = None,
-    role: Annotated[
-        list[str] | None,
-        typer.Option("--role", "-r", help="Render only roles matching (substring of name/id)"),
-    ] = None,
-    yes: Annotated[
-        bool, typer.Option("--yes", "-y", help="Skip overwrite prompt for output files")
-    ] = False,
-    project_dir: Annotated[
-        str | None, typer.Option("--project-dir", help="Project root directory")
-    ] = None,
-) -> None:
-    """Render installed role definitions to platform configs (optionally filter by --role)."""
-    _render_command(target=target, project_dir=project_dir, role=role, yes=yes)
+    _success(f"{len(payload)} source(s) recorded in this project")
 
 
 @app.command()
 def remove(
-    agent_name: Annotated[str, typer.Argument(help="Agent canonical id or unique name to remove")],
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="Remove from ~/.agents/roles/")
-    ] = False,
-    project_dir: Annotated[
-        str | None, typer.Option("--project-dir", help="Project root directory")
-    ] = None,
-) -> None:
-    """Remove an installed agent definition from one scope."""
-    project = _resolve_project(project_dir)
-    roles_dir, agents = _load_agents_in_scope(project, _resolve_scope(global_install))
-    agent = _resolve_remove_target(agents, agent_name)
-    agent_file = agent.source_path or roles_dir / agent.install_relative_path()
-    rel_path = agent.install_relative_path()
-    agent_file.unlink()
-    from role_forge.manifest import remove_path_from_manifest
-
-    remove_path_from_manifest(roles_dir, rel_path)
-    _success(f"Removed {agent.canonical_id}")
-    _info("If target files still reference it, run `role-forge render` to regenerate outputs.")
-
-
-@app.command()
-def doctor(
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="Inspect ~/.agents/roles/")
-    ] = False,
-    json_output: Annotated[bool, typer.Option("--json", help="Output findings as JSON")] = False,
-    project_dir: Annotated[
-        str | None, typer.Option("--project-dir", help="Project root directory")
-    ] = None,
-) -> None:
-    """Inspect unmanaged files under the selected roles directory."""
-    project = _resolve_project(project_dir)
-    scope = _resolve_scope(global_install)
-    roles_dir, issues = _scan_unmanaged_files(project, scope)
-
-    payload = {
-        "scope": scope,
-        "roles_dir": str(roles_dir),
-        "issue_count": len(issues),
-        "issues": [
-            {
-                "path": str(issue.path),
-                "relative_path": issue.path.relative_to(roles_dir).as_posix(),
-                "reason": issue.reason,
-            }
-            for issue in issues
-        ],
-    }
-
-    if json_output:
-        typer.echo(json.dumps(payload, indent=2))
-        return
-
-    if not issues:
-        _success(f"No unmanaged files found in {_scope_label(scope)} scope")
-        typer.echo(_dim(f"  {roles_dir}"))
-        return
-
-    _warn(f"Found {len(issues)} unmanaged file(s) in {_scope_label(scope)} scope")
-    typer.echo(_dim(f"  {roles_dir}"))
-    for issue in issues:
-        relative_path = issue.path.relative_to(roles_dir).as_posix()
-        typer.echo(_bullet(relative_path, issue.reason))
-
-
-@app.command()
-def clean(
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="Clean ~/.agents/roles/")
-    ] = False,
-    dry_run: Annotated[
-        bool, typer.Option("--dry-run", help="Show unmanaged files without deleting")
-    ] = False,
+    source: Annotated[str, typer.Argument(help="Source to remove: org/repo[@ref] or local path")],
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
     project_dir: Annotated[
         str | None, typer.Option("--project-dir", help="Project root directory")
     ] = None,
 ) -> None:
-    """Delete unmanaged files under the selected roles directory."""
+    """Remove a source, clean generated outputs, and clear cached state."""
+    from role_forge.outputs import (
+        delete_recorded_files,
+        load_output_manifest,
+        remove_source_outputs,
+    )
+    from role_forge.registry import parse_source
+
     project = _resolve_project(project_dir)
-    scope = _resolve_scope(global_install)
-    roles_dir, issues = _scan_unmanaged_files(project, scope)
+    parsed = parse_source(source)
+    source_key = _normalize_source_ref(parsed)
 
-    if not issues:
-        _success(f"No unmanaged files found in {_scope_label(scope)} scope")
-        typer.echo(_dim(f"  {roles_dir}"))
-        return
-
-    heading = "Would remove" if dry_run else "Removing"
-    _warn(f"{heading} {len(issues)} unmanaged file(s) from {_scope_label(scope)} scope")
-    typer.echo(_dim(f"  {roles_dir}"))
-    for issue in issues:
-        relative_path = issue.path.relative_to(roles_dir).as_posix()
-        typer.echo(_bullet(relative_path, issue.reason))
-
-    if dry_run:
-        return
-
-    if not yes and not typer.confirm(f"Remove {len(issues)} unmanaged file(s)?", default=False):
-        _warn("Clean cancelled.")
+    entries = load_output_manifest(project)
+    entry = entries.get(source_key)
+    if entry is None and parsed.is_local:
+        _error(f"Source not recorded in this project: {source_key}")
         raise typer.Exit(1)
 
-    for issue in issues:
-        issue.path.unlink()
+    if not yes and not typer.confirm(
+        f"Remove source {source_key} and clean generated outputs?", default=True
+    ):
+        _warn("Remove cancelled.")
+        raise typer.Exit(1)
 
-    _success(f"Removed {len(issues)} unmanaged file(s)")
+    deleted_count = 0
+    if entry is not None:
+        deleted_count = len(delete_recorded_files(project, entry))
+        remaining_entries = remove_source_outputs(project, source_key)
+    else:
+        remaining_entries = entries
+
+    if not parsed.is_local:
+        _delete_cached_source(source_key)
+
+    if remaining_entries:
+        _rebuild_remaining_outputs(project, remaining_entries)
+
+    _success(f"Removed source {source_key}")
+    _info(f"Deleted {deleted_count} generated file(s).")
 
 
 @app.command()
 def update(
-    source: Annotated[str, typer.Argument(help="Source to update: org/repo")],
-    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip all prompts")] = False,
-    global_install: Annotated[
-        bool, typer.Option("--global", "-g", help="Update ~/.agents/roles/")
-    ] = False,
+    source: Annotated[str, typer.Argument(help="GitHub source to refresh: org/repo[@ref]")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip overwrite prompts")] = False,
     target: Annotated[
         list[str] | None,
-        typer.Option("--target", "-t", help="Render to these targets (default: toml or auto)"),
+        typer.Option(
+            "--target", "-t", help="Generate these targets (default: previous/source/auto)"
+        ),
     ] = None,
-    no_render: Annotated[
-        bool,
-        typer.Option("--no-render", help="Skip render after update"),
-    ] = False,
     role: Annotated[
         list[str] | None,
-        typer.Option("--role", "-r", help="Update only roles matching (substring of name/id)"),
+        typer.Option("--role", "-r", help="Generate only roles matching (substring of name/id)"),
     ] = None,
     project_dir: Annotated[
         str | None, typer.Option("--project-dir", help="Project root directory")
     ] = None,
 ) -> None:
-    """Update from a previously added source. Renders to targets by default (toml or -t)."""
+    """Refresh a remote source and regenerate its outputs."""
     from role_forge.registry import parse_source
 
     parsed = parse_source(source)
     if parsed.is_local:
-        _error("Cannot update a local source. Use 'add' instead.")
+        _error("Cannot update a local source. Use 'add' again instead.")
         raise typer.Exit(1)
 
     add(
         source=source,
         yes=yes,
-        global_install=global_install,
         target=target,
-        no_render=no_render,
         role=role,
         project_dir=project_dir,
     )

--- a/src/role_forge/config.py
+++ b/src/role_forge/config.py
@@ -10,16 +10,26 @@ from loguru import logger
 from role_forge.models import ProjectConfig, TargetConfig
 
 CONFIG_FILENAME = "roles.toml"
-USER_ROLES_DIR = Path.home() / ".agents" / "roles"
+DEFAULT_SOURCE_ROLES_DIR = "roles"
+PROJECT_STATE_DIR = Path(".role-forge")
+OUTPUT_MANIFEST_FILENAME = "outputs.json"
 
 
 class ConfigError(Exception):
     """Raised when roles.toml is invalid or missing."""
 
 
-def resolve_roles_dir(project: Path) -> Path:
-    """Return the canonical roles directory for a project."""
-    return project / ".agents" / "roles"
+def resolve_source_roles_dir(project: Path) -> Path:
+    """Return the canonical source roles directory for a project."""
+    config_path = find_config(project)
+    if config_path is None:
+        return project / DEFAULT_SOURCE_ROLES_DIR
+    return project / load_config(config_path).roles_dir
+
+
+def resolve_output_manifest_path(project: Path) -> Path:
+    """Return the local project output manifest path."""
+    return project / PROJECT_STATE_DIR / OUTPUT_MANIFEST_FILENAME
 
 
 def find_config(project: Path) -> Path | None:
@@ -37,7 +47,7 @@ def load_config(config_path: Path) -> ProjectConfig:
         data = tomllib.load(f)
 
     project = data.get("project", {})
-    roles_dir = project.get("roles_dir", "roles")
+    roles_dir = project.get("roles_dir", DEFAULT_SOURCE_ROLES_DIR)
 
     raw_targets = data.get("targets", {})
     targets = {}

--- a/src/role_forge/loader.py
+++ b/src/role_forge/loader.py
@@ -1,16 +1,14 @@
-"""Loader for canonical agent definitions (.agents/roles/*.md)."""
+"""Loader for canonical agent definitions."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
 import yaml
 from loguru import logger
 from pydantic import ValidationError
 
-from role_forge import config as config_module
 from role_forge.models import AgentDef, HierarchyConfig, ModelConfig
 
 
@@ -50,36 +48,6 @@ def load_agents(roles_dir: Path, *, strict: bool = False) -> list[AgentDef]:
             logger.warning(f"Skipping {md_path.relative_to(roles_dir)}: {exc}", exc_info=True)
     logger.debug(f"Loaded {len(agents)} agent(s) from {roles_dir}")
     return agents
-
-
-def load_agents_in_scope(
-    project: Path,
-    *,
-    scope: Literal["project", "user"],
-) -> tuple[Path, list[AgentDef]]:
-    """Load agent definitions from a single install scope."""
-    roles_dir = (
-        config_module.resolve_roles_dir(project)
-        if scope == "project"
-        else config_module.USER_ROLES_DIR
-    )
-    if not roles_dir.is_dir():
-        return roles_dir, []
-    return roles_dir, load_agents(roles_dir, strict=True)
-
-
-def load_merged_agents(project: Path, *, include_user: bool = True) -> list[AgentDef]:
-    """Load effective agents with project scope overriding user scope."""
-    merged: dict[str, AgentDef] = {}
-
-    if include_user:
-        _, user_agents = load_agents_in_scope(project, scope="user")
-        merged.update({agent.canonical_id: agent for agent in user_agents})
-
-    _, project_agents = load_agents_in_scope(project, scope="project")
-    merged.update({agent.canonical_id: agent for agent in project_agents})
-
-    return [merged[canonical_id] for canonical_id in sorted(merged)]
 
 
 def find_unmanaged_files(roles_dir: Path) -> list[UnmanagedFileIssue]:

--- a/src/role_forge/manifest.py
+++ b/src/role_forge/manifest.py
@@ -1,87 +1,96 @@
-"""Manifest tracking which source installed which role files for prune on update."""
+"""Global cache manifest for fetched source repositories."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
-MANIFEST_FILENAME = ".role-forge-manifest.json"
+from role_forge.registry import CACHE_ROOT
+
+MANIFEST_FILENAME = "manifest.json"
 
 
-def _manifest_path(roles_dir: Path) -> Path:
-    return roles_dir / MANIFEST_FILENAME
+def manifest_path(root: Path | None = None) -> Path:
+    """Return the global cache manifest path."""
+    base = root or CACHE_ROOT
+    return base / MANIFEST_FILENAME
 
 
-def load_manifest(roles_dir: Path) -> dict[str, list[str]]:
-    """Load manifest from roles_dir. Returns {source_key: [relative_path, ...]}."""
-    path = _manifest_path(roles_dir)
+def _normalize_manifest(data: Any) -> dict[str, dict[str, str]]:
+    if not isinstance(data, dict):
+        return {}
+
+    raw_sources = data.get("sources", data)
+    if not isinstance(raw_sources, dict):
+        return {}
+
+    normalized: dict[str, dict[str, str]] = {}
+    for source_key, raw_entry in raw_sources.items():
+        if not isinstance(raw_entry, dict):
+            continue
+
+        entry: dict[str, str] = {}
+        for field in ("cache_key", "cache_path", "last_fetched_commit"):
+            value = raw_entry.get(field)
+            if isinstance(value, str) and value:
+                entry[field] = value
+
+        if entry:
+            normalized[str(source_key)] = entry
+
+    return normalized
+
+
+def load_manifest(root: Path | None = None) -> dict[str, dict[str, str]]:
+    """Load the global cache manifest."""
+    path = manifest_path(root)
     if not path.is_file():
         return {}
+
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            return {}
-        result: dict[str, list[str]] = {}
-        for k, v in data.items():
-            if isinstance(v, list):
-                result[str(k)] = [str(p) for p in v]
-        return result
     except (json.JSONDecodeError, OSError):
         return {}
 
-
-def save_manifest(roles_dir: Path, manifest: dict[str, list[str]]) -> None:
-    """Write manifest to roles_dir."""
-    path = _manifest_path(roles_dir)
-    path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return _normalize_manifest(data)
 
 
-def paths_for_source(manifest: dict[str, list[str]], source_key: str) -> list[str]:
-    """Return paths previously installed by this source."""
-    return list(manifest.get(source_key, []))
+def save_manifest(manifest: dict[str, dict[str, str]], root: Path | None = None) -> None:
+    """Write the global cache manifest."""
+    path = manifest_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": 1, "sources": _normalize_manifest(manifest)}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def update_manifest_for_source(
-    roles_dir: Path,
+def update_source(
     source_key: str,
-    installed_paths: list[str],
+    *,
+    cache_key: str,
+    cache_path: Path,
+    last_fetched_commit: str,
+    root: Path | None = None,
 ) -> None:
-    """Update manifest: set source_key -> installed_paths, persist."""
-    manifest = load_manifest(roles_dir)
-    manifest[source_key] = sorted(installed_paths)
-    save_manifest(roles_dir, manifest)
+    """Upsert one cached source entry."""
+    manifest = load_manifest(root)
+    manifest[source_key] = {
+        "cache_key": cache_key,
+        "cache_path": str(cache_path),
+        "last_fetched_commit": last_fetched_commit,
+    }
+    save_manifest(manifest, root)
 
 
-def prune_orphaned(
-    roles_dir: Path,
-    source_key: str,
-    current_paths: set[str],
-) -> list[Path]:
-    """Remove files that were installed by source but no longer in current_paths.
-
-    Returns list of paths that were deleted. Caller must update manifest after copy.
-    """
-    manifest = load_manifest(roles_dir)
-    previous = set(paths_for_source(manifest, source_key))
-    orphaned = previous - current_paths
-    deleted: list[Path] = []
-    for rel in orphaned:
-        path = roles_dir / rel
-        if path.is_file():
-            path.unlink()
-            deleted.append(path)
-    return deleted
+def remove_source(source_key: str, root: Path | None = None) -> None:
+    """Delete one cached source entry."""
+    manifest = load_manifest(root)
+    if source_key not in manifest:
+        return
+    del manifest[source_key]
+    save_manifest(manifest, root)
 
 
-def remove_path_from_manifest(roles_dir: Path, relative_path: str) -> None:
-    """Remove a path from all manifest entries (e.g. after manual remove)."""
-    manifest = load_manifest(roles_dir)
-    changed = False
-    for key in list(manifest.keys()):
-        if relative_path in manifest[key]:
-            manifest[key] = [p for p in manifest[key] if p != relative_path]
-            changed = True
-            if not manifest[key]:
-                del manifest[key]
-    if changed:
-        save_manifest(roles_dir, manifest)
+def source_entry(source_key: str, root: Path | None = None) -> dict[str, str] | None:
+    """Return one cached source entry."""
+    return load_manifest(root).get(source_key)

--- a/src/role_forge/models.py
+++ b/src/role_forge/models.py
@@ -80,7 +80,7 @@ class AgentDef(BaseModel, frozen=True):
         return self.canonical_id
 
     def install_relative_path(self) -> str:
-        """Canonical install path beneath `.agents/roles`."""
+        """Canonical relative path within the source role tree."""
         if self.relative_path:
             return self.relative_path
         return f"{self.name}.md"
@@ -113,7 +113,7 @@ class ProjectConfig(BaseModel, frozen=True):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    roles_dir: str = Field(default=".agents/roles", alias="roles_dir")
+    roles_dir: str = Field(default="roles", alias="roles_dir")
     targets: dict[str, TargetConfig] = Field(default_factory=dict)
 
 

--- a/src/role_forge/outputs.py
+++ b/src/role_forge/outputs.py
@@ -1,0 +1,164 @@
+"""Project-local generated output ownership manifest."""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from role_forge.config import resolve_output_manifest_path
+
+
+def _normalize_target_entry(raw_entry: Any) -> dict[str, list[str]] | None:
+    if not isinstance(raw_entry, dict):
+        return None
+
+    files = raw_entry.get("files", [])
+    selected_roles = raw_entry.get("selected_roles", [])
+    if not isinstance(files, list) or not isinstance(selected_roles, list):
+        return None
+
+    normalized = {
+        "files": [str(path) for path in files if isinstance(path, str)],
+        "selected_roles": [str(role) for role in selected_roles if isinstance(role, str)],
+    }
+    if not normalized["files"]:
+        return None
+    return normalized
+
+
+def _normalize_targets(raw_targets: Any) -> dict[str, dict[str, list[str]]]:
+    if not isinstance(raw_targets, dict):
+        return {}
+
+    normalized: dict[str, dict[str, list[str]]] = {}
+    for target_name, raw_entry in raw_targets.items():
+        entry = _normalize_target_entry(raw_entry)
+        if entry is not None:
+            normalized[str(target_name)] = entry
+    return normalized
+
+
+def _normalize_sources(raw_sources: Any) -> OrderedDict[str, dict[str, Any]]:
+    normalized: OrderedDict[str, dict[str, Any]] = OrderedDict()
+    if not isinstance(raw_sources, dict):
+        return normalized
+
+    for source_key, raw_entry in raw_sources.items():
+        if not isinstance(raw_entry, dict):
+            continue
+
+        source = raw_entry.get("source")
+        targets = _normalize_targets(raw_entry.get("targets", {}))
+        if not isinstance(source, str) or not source or not targets:
+            continue
+
+        normalized[str(source_key)] = {
+            "source": source,
+            "targets": targets,
+        }
+
+    return normalized
+
+
+def load_output_manifest(project: Path) -> OrderedDict[str, dict[str, Any]]:
+    """Load the project-local output manifest."""
+    path = resolve_output_manifest_path(project)
+    if not path.is_file():
+        return OrderedDict()
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return OrderedDict()
+
+    raw_sources = data.get("sources", data)
+    return _normalize_sources(raw_sources)
+
+
+def save_output_manifest(project: Path, sources: OrderedDict[str, dict[str, Any]]) -> None:
+    """Persist the project-local output manifest."""
+    path = resolve_output_manifest_path(project)
+    if not sources:
+        if path.exists():
+            path.unlink()
+        _prune_empty_dirs(path.parent, project)
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": 1, "sources": _normalize_sources(sources)}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def update_source_outputs(
+    project: Path,
+    *,
+    source_key: str,
+    source: str,
+    targets: dict[str, dict[str, list[str]]],
+) -> OrderedDict[str, dict[str, Any]]:
+    """Upsert one source entry and move it to the end for precedence."""
+    sources = load_output_manifest(project)
+    existing_targets = {}
+    if source_key in sources:
+        existing_targets = dict(sources[source_key].get("targets", {}))
+        del sources[source_key]
+
+    merged_targets = dict(existing_targets)
+    merged_targets.update(targets)
+    sources[source_key] = {
+        "source": source,
+        "targets": {
+            target_name: {
+                "selected_roles": list(entry["selected_roles"]),
+                "files": sorted(entry["files"]),
+            }
+            for target_name, entry in merged_targets.items()
+        },
+    }
+    save_output_manifest(project, sources)
+    return sources
+
+
+def remove_source_outputs(project: Path, source_key: str) -> OrderedDict[str, dict[str, Any]]:
+    """Remove one source entry from the project output manifest."""
+    sources = load_output_manifest(project)
+    if source_key in sources:
+        del sources[source_key]
+    save_output_manifest(project, sources)
+    return sources
+
+
+def recorded_files(entry: dict[str, Any]) -> list[str]:
+    """Return all recorded output files for one source entry."""
+    targets = entry.get("targets", {})
+    files: list[str] = []
+    for target_entry in targets.values():
+        files.extend(str(path) for path in target_entry.get("files", []))
+    return files
+
+
+def delete_recorded_files(project: Path, entry: dict[str, Any]) -> list[Path]:
+    """Delete files recorded for one source entry and prune empty directories."""
+    deleted: list[Path] = []
+    for relative_path in recorded_files(entry):
+        path = project / relative_path
+        if path.is_file():
+            path.unlink()
+            deleted.append(path)
+            _prune_empty_dirs(path.parent, project)
+    return deleted
+
+
+def _prune_empty_dirs(path: Path, project: Path) -> None:
+    current = path
+    project_root = project.resolve()
+    while current.exists() and current.is_dir():
+        if current.resolve() == project_root:
+            return
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent

--- a/src/role_forge/registry.py
+++ b/src/role_forge/registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from role_forge.config import find_config, load_config
+from role_forge.config import resolve_source_roles_dir
 
 
 @dataclass
@@ -67,7 +67,8 @@ def parse_source(source: str) -> ParsedSource:
     return ParsedSource(org=parts[0], repo=parts[1], ref=ref)
 
 
-CACHE_DIR = Path.home() / ".config" / "role-forge" / "repos"
+CACHE_ROOT = Path.home() / ".config" / "role-forge"
+CACHE_DIR = CACHE_ROOT / "repos"
 
 
 def fetch_source(source: ParsedSource, cache_root: Path | None = None) -> Path:
@@ -90,6 +91,25 @@ def fetch_source(source: ParsedSource, cache_root: Path | None = None) -> Path:
         _git_clone(source.github_url, cache, source.ref)
 
     return cache
+
+
+def cache_path_for_source(source: ParsedSource, cache_root: Path | None = None) -> Path:
+    """Return the cache path for a parsed remote source."""
+    if source.is_local:
+        raise ValueError("Local sources do not use the repo cache.")
+    return (cache_root or CACHE_DIR) / source.cache_key
+
+
+def read_head_commit(repo_dir: Path) -> str:
+    """Return the current HEAD commit for a fetched repo."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 def _git_clone(url: str, dest: Path, ref: str | None) -> None:
@@ -206,19 +226,11 @@ def _ensure_head_checked_out(repo_dir: Path, ref: str | None) -> None:
 def find_roles_dir(repo_path: Path) -> Path:
     """Find the **source** roles directory in a repo.
 
-    `.agents/roles/` is the *install* target (generated/copied), never source.
-
     Priority:
     1. roles.toml ``[project].roles_dir`` setting
     2. ``roles/`` directory (standard source layout)
     """
-    config_path = find_config(repo_path)
-    if config_path is not None:
-        roles_dir = repo_path / load_config(config_path).roles_dir
-        if roles_dir.is_dir():
-            return roles_dir
-
-    roles_dir = repo_path / "roles"
+    roles_dir = resolve_source_roles_dir(repo_path)
     if roles_dir.is_dir():
         return roles_dir
 

--- a/tests/fixtures/roles.toml
+++ b/tests/fixtures/roles.toml
@@ -1,5 +1,5 @@
 [project]
-roles_dir = ".agents/roles"
+roles_dir = "roles"
 
 [targets.opencode]
 enabled = true

--- a/tests/fixtures/roles/aligner.md
+++ b/tests/fixtures/roles/aligner.md
@@ -1,0 +1,19 @@
+---
+name: aligner
+description: Precision Aligner. Makes targeted code changes.
+role: subagent
+
+model:
+  tier: coding
+  temperature: 0.1
+
+skills: []
+
+capabilities:
+  - read
+  - write
+---
+
+# Aligner
+
+Makes targeted code changes to align implementations.

--- a/tests/fixtures/roles/explorer.md
+++ b/tests/fixtures/roles/explorer.md
@@ -1,0 +1,25 @@
+---
+name: explorer
+description: Code Explorer. Reads and analyzes source code.
+role: subagent
+
+model:
+  tier: reasoning
+  temperature: 0.05
+
+skills:
+  - repomix-explorer
+
+capabilities:
+  - read
+  - write
+  - web-access
+  - context7
+  - bash:
+      - "npx repomix@latest*"
+      - "bunx repomix@latest*"
+---
+
+# Explorer
+
+Read-only code exploration agent. Traces execution paths and produces reports.

--- a/tests/fixtures/roles/nested/feature-lead.md
+++ b/tests/fixtures/roles/nested/feature-lead.md
@@ -1,0 +1,29 @@
+---
+name: feature-lead
+description: Nested lead fixture that exercises the `all` capability.
+role: subagent
+
+model:
+  tier: coding
+  temperature: 0.1
+
+capabilities:
+  - all
+  - delegate:
+      - nested/workers/impl-worker
+      - nested/workers/qa-worker
+
+hierarchy:
+  level: L2
+  class: lead
+  scheduled: false
+  callable: true
+  max_delegate_depth: 1
+  allowed_children:
+    - nested/workers/impl-worker
+    - nested/workers/qa-worker
+---
+
+# Feature Lead
+
+Exercises full capability expansion in a nested fixture.

--- a/tests/fixtures/roles/nested/nested-coordinator.md
+++ b/tests/fixtures/roles/nested/nested-coordinator.md
@@ -1,0 +1,30 @@
+---
+name: nested-coordinator
+description: Nested test coordinator for recursive fixture coverage.
+role: primary
+
+model:
+  tier: reasoning
+  temperature: 0.2
+
+capabilities:
+  - read
+  - write
+  - delegate:
+      - nested/feature-lead
+      - nested/support/research-helper
+
+hierarchy:
+  level: L1
+  class: main
+  scheduled: true
+  callable: true
+  max_delegate_depth: 2
+  allowed_children:
+    - nested/feature-lead
+    - nested/support/research-helper
+---
+
+# Nested Coordinator
+
+Coordinates the nested test roles.

--- a/tests/fixtures/roles/nested/support/research-helper.md
+++ b/tests/fixtures/roles/nested/support/research-helper.md
@@ -1,0 +1,24 @@
+---
+name: research-helper
+description: Nested research helper fixture.
+role: subagent
+
+model:
+  tier: reasoning
+  temperature: 0.05
+
+capabilities:
+  - read
+  - web-access
+
+hierarchy:
+  level: L3
+  class: leaf
+  scheduled: false
+  callable: true
+  max_delegate_depth: 0
+---
+
+# Research Helper
+
+Collects supporting context for nested fixture tests.

--- a/tests/fixtures/roles/nested/workers/impl-worker.md
+++ b/tests/fixtures/roles/nested/workers/impl-worker.md
@@ -1,0 +1,24 @@
+---
+name: impl-worker
+description: Nested implementation worker fixture.
+role: subagent
+
+model:
+  tier: coding
+  temperature: 0.1
+
+capabilities:
+  - read
+  - write
+
+hierarchy:
+  level: L3
+  class: leaf
+  scheduled: false
+  callable: true
+  max_delegate_depth: 0
+---
+
+# Impl Worker
+
+Implements changes in nested fixture tests.

--- a/tests/fixtures/roles/nested/workers/qa-worker.md
+++ b/tests/fixtures/roles/nested/workers/qa-worker.md
@@ -1,0 +1,24 @@
+---
+name: qa-worker
+description: Nested QA worker fixture.
+role: subagent
+
+model:
+  tier: reasoning
+  temperature: 0.05
+
+capabilities:
+  - read
+  - safe-bash
+
+hierarchy:
+  level: L3
+  class: leaf
+  scheduled: false
+  callable: true
+  max_delegate_depth: 0
+---
+
+# QA Worker
+
+Verifies nested fixture behavior.

--- a/tests/fixtures/roles/orchestrator.md
+++ b/tests/fixtures/roles/orchestrator.md
@@ -1,0 +1,26 @@
+---
+name: orchestrator
+description: Orchestrator. Coordinates sub-agents.
+role: primary
+
+model:
+  tier: reasoning
+  temperature: 0.2
+
+skills: []
+
+capabilities:
+  - read
+  - write
+  - bash:
+      - "ls*"
+      - "cat*"
+      - "git status*"
+  - delegate:
+      - explorer
+      - aligner
+---
+
+# Orchestrator
+
+Coordinates exploration and alignment sub-agents.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,13 +3,64 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
-import role_forge.config as config_module
 from role_forge.cli import app
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolate_global_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("role_forge.manifest.CACHE_ROOT", tmp_path / "global-state")
+
+
+def _write_role(path: Path, name: str, *, tier: str = "reasoning", body: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prompt = body or f"# {name}\n"
+    path.write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {name}\n"
+        "role: subagent\n"
+        "model:\n"
+        f"  tier: {tier}\n"
+        "capabilities:\n"
+        "  - read\n"
+        "---\n"
+        f"{prompt}"
+    )
+
+
+def _write_source_config(path: Path, target_name: str = "claude") -> None:
+    if target_name == "claude":
+        path.write_text(
+            '[project]\nroles_dir = "roles"\n\n'
+            "[targets.claude]\nenabled = true\n"
+            "[targets.claude.model_map]\n"
+            'reasoning = "source-opus"\n'
+            'coding = "source-sonnet"\n'
+        )
+        return
+
+    path.write_text(
+        '[project]\nroles_dir = "roles"\n\n'
+        "[targets.opencode]\nenabled = true\n"
+        "[targets.opencode.model_map]\n"
+        'reasoning = "my-reasoning-model"\n'
+        'coding = "my-coding-model"\n'
+    )
+
+
+def _remote_source(source_root: Path, *, target_name: str = "claude") -> Path:
+    roles = source_root / "roles"
+    roles.mkdir(parents=True)
+    _write_role(roles / "explorer.md", "explorer")
+    _write_source_config(source_root / "roles.toml", target_name=target_name)
+    return source_root
 
 
 def test_version():
@@ -18,653 +69,117 @@ def test_version():
     assert "role-forge" in result.output
 
 
-# -- add command ---------------------------------------------------------------
-
-
-def test_add_from_local(tmp_path):
-    """add from a local path should confirm and install roles."""
+def test_add_local_generates_outputs_and_manifest(tmp_path):
     source = tmp_path / "source"
     roles = source / "roles"
     roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n---\n# Explorer\n"
-    )
+    _write_role(roles / "explorer.md", "explorer")
 
     project = tmp_path / "project"
-    project.mkdir()
+    (project / ".claude").mkdir(parents=True)
 
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert (project / ".agents" / "roles" / "explorer.md").is_file()
-
-
-def test_add_yes_skips_install_confirmation(tmp_path):
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        ["add", str(source), "--yes", "--project-dir", str(project)],
-    )
+    result = runner.invoke(app, ["add", str(source), "--yes", "--project-dir", str(project)])
 
     assert result.exit_code == 0, result.output
-    assert "Continue with install?" not in result.output
+    agent_file = project / ".claude" / "agents" / "explorer.md"
+    assert agent_file.is_file()
+    outputs_manifest = json.loads((project / ".role-forge" / "outputs.json").read_text())
+    source_entry = outputs_manifest["sources"][str(source.resolve())]
+    assert source_entry["source"] == str(source.resolve())
+    assert source_entry["targets"]["claude"]["selected_roles"] == ["explorer"]
+    assert source_entry["targets"]["claude"]["files"] == [".claude/agents/explorer.md"]
 
 
-def test_add_without_yes_can_cancel_install(tmp_path):
+def test_add_without_targets_only_validates_and_caches(tmp_path):
     source = tmp_path / "source"
     roles = source / "roles"
     roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    project = tmp_path / "project"
-    project.mkdir()
-    target_file = project / ".agents" / "roles" / "explorer.md"
-    target_file.parent.mkdir(parents=True)
-    target_file.write_text("---\nname: explorer\n---\n# Existing\n")
-
-    result = runner.invoke(
-        app,
-        ["add", str(source), "--project-dir", str(project)],
-        input="p\nn\n",  # scope: project, then cancel overwrite
-    )
-
-    assert result.exit_code == 1
-    assert target_file.read_text() == "---\nname: explorer\n---\n# Existing\n"
-
-
-def test_add_without_yes_prompts_before_overwrite(tmp_path):
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text("---\nname: explorer\n---\n# New Explorer\n")
-    project_roles = tmp_path / "project" / ".agents" / "roles"
-    project_roles.mkdir(parents=True)
-    existing = project_roles / "explorer.md"
-    existing.write_text("---\nname: explorer\n---\n# Old Explorer\n")
-
-    # One overwrite prompt: n = skip overwrites, no new roles -> cancel (exit 1)
-    result = runner.invoke(
-        app,
-        ["add", str(source), "--project-dir", str(tmp_path / "project")],
-        input="p\nn\n",  # scope: project, skip overwrites
-    )
-    assert result.exit_code == 1, result.output
-    assert existing.read_text() == "---\nname: explorer\n---\n# Old Explorer\n"
-
-    # One overwrite prompt: y = overwrite all
-    result2 = runner.invoke(
-        app,
-        ["add", str(source), "--project-dir", str(tmp_path / "project")],
-        input="p\ny\n",  # scope: project, allow overwrite
-    )
-    assert result2.exit_code == 0, result2.output
-    assert existing.read_text() == "---\nname: explorer\n---\n# New Explorer\n"
-
-
-def test_add_with_auto_cast(tmp_path):
-    """add should auto-cast when platform is detected."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
+    _write_role(roles / "explorer.md", "explorer")
 
     project = tmp_path / "project"
     project.mkdir()
-    (project / ".claude").mkdir()
 
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--project-dir",
-            str(project),
-        ],
-    )
+    result = runner.invoke(app, ["add", str(source), "--yes", "--project-dir", str(project)])
+
     assert result.exit_code == 0, result.output
-    assert (project / ".claude" / "agents" / "explorer.md").is_file()
+    assert "No target detected" in result.output
+    assert not (project / ".role-forge" / "outputs.json").exists()
 
 
-def test_add_no_render_skips_render(tmp_path):
-    """add --no-render installs roles but does not render to targets."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
+def test_add_uses_source_repo_target_config(tmp_path):
+    source = _remote_source(tmp_path / "source", target_name="opencode")
+    _write_role(source / "roles" / "explorer.md", "explorer", tier="reasoning")
+
     project = tmp_path / "project"
     project.mkdir()
-    (project / ".claude").mkdir()
 
     result = runner.invoke(
         app,
-        ["add", str(source), "--yes", "--no-render", "--project-dir", str(project)],
+        ["add", str(source), "--yes", "--target", "opencode", "--project-dir", str(project)],
     )
+
     assert result.exit_code == 0, result.output
-    assert (project / ".agents" / "roles" / "explorer.md").is_file()
-    assert not (project / ".claude" / "agents" / "explorer.md").exists()
+    content = (project / ".opencode" / "agents" / "explorer.md").read_text()
+    assert "my-reasoning-model" in content
 
 
-def test_add_role_filter_installs_only_matching(tmp_path):
-    """add --role installs only roles whose name/id match (substring)."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    for name in ("explorer", "writer", "aligner"):
-        (roles / f"{name}.md").write_text(
-            "---\nname: " + name + "\ndescription: x\nrole: subagent\n"
-            "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# x\n"
-        )
+def test_add_remote_updates_global_cache_manifest(tmp_path, monkeypatch):
+    cache = _remote_source(tmp_path / "cache")
     project = tmp_path / "project"
-    project.mkdir()
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--no-render",
-            "--role",
-            "explorer",
-            "--project-dir",
-            str(project),
-        ],
-    )
+    (project / ".claude").mkdir(parents=True)
+
+    monkeypatch.setattr("role_forge.registry.fetch_source", lambda parsed: cache)
+    monkeypatch.setattr("role_forge.registry.read_head_commit", lambda repo_dir: "abc123def456")
+
+    result = runner.invoke(app, ["add", "org/repo", "--yes", "--project-dir", str(project)])
+
     assert result.exit_code == 0, result.output
-    assert (project / ".agents" / "roles" / "explorer.md").is_file()
-    assert not (project / ".agents" / "roles" / "writer.md").exists()
-    assert not (project / ".agents" / "roles" / "aligner.md").exists()
-
-
-def test_add_with_explicit_target(tmp_path):
-    """add --target should cast to specified platform only."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert (project / ".claude" / "agents" / "explorer.md").is_file()
-
-
-def test_add_fails_when_source_contains_invalid_role(tmp_path):
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "good.md").write_text("---\nname: good\n---\n# Good\n")
-    (roles / "bad.md").write_text("not valid frontmatter\n")
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        ["add", str(source), "--yes", "--no-render", "--project-dir", str(project)],
-    )
-
-    assert result.exit_code == 1
-    assert "bad.md" in result.output
-    assert not (project / ".agents" / "roles" / "good.md").exists()
-
-
-def test_add_preserves_nested_role_paths_and_cast_output(tmp_path):
-    source = tmp_path / "source"
-    roles = source / "roles"
-    (roles / "l2").mkdir(parents=True)
-    (roles / "l3").mkdir(parents=True)
-    (roles / "l2" / "lead.md").write_text(
-        "---\nname: lead\ndescription: Lead\nrole: subagent\nlevel: L2\n---\n# Lead\n"
-    )
-    (roles / "l3" / "worker.md").write_text(
-        "---\nname: worker\ndescription: Worker\nrole: subagent\nlevel: L3\n---\n# Worker\n"
-    )
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert (project / ".agents" / "roles" / "l2" / "lead.md").is_file()
-    assert (project / ".agents" / "roles" / "l3" / "worker.md").is_file()
-    assert (project / ".claude" / "agents" / "l2" / "lead.md").is_file()
-    assert (project / ".claude" / "agents" / "l3" / "worker.md").is_file()
-
-
-# -- list command --------------------------------------------------------------
-
-
-def test_list_agents(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\n---\n# Explorer\n"
-    )
-    result = runner.invoke(app, ["list", "--project-dir", str(tmp_path)])
-    assert result.exit_code == 0
-    assert "explorer" in result.output
-
-
-def test_list_global_reads_only_user_scope(tmp_path, monkeypatch):
-    project_roles = tmp_path / "project" / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-    (project_roles / "project.md").write_text("---\nname: project\n---\n# Project")
-    (user_roles / "user.md").write_text("---\nname: user\n---\n# User")
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    result = runner.invoke(app, ["list", "-g", "--project-dir", str(tmp_path / "project")])
-
-    assert result.exit_code == 0
-    assert "user" in result.output
-    assert "project" not in result.output
-
-
-def test_list_json_outputs_machine_readable_roles(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer")
-
-    result = runner.invoke(app, ["list", "--json", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 0
+    result = runner.invoke(app, ["list", "--sources", "--json", "--project-dir", str(project)])
     payload = json.loads(result.output)
     assert payload == [
         {
-            "name": "explorer",
-            "canonical_id": "explorer",
-            "role": "subagent",
-            "tier": "reasoning",
-            "temperature": None,
-            "relative_path": "explorer.md",
-            "source_path": str((roles_dir / "explorer.md").resolve()),
-            "scope": "project",
+            "source_key": "org/repo",
+            "cache_key": "org/repo",
+            "cache_path": str(cache),
+            "last_fetched_commit": "abc123def456",
         }
     ]
 
 
-def test_list_no_agents(tmp_path):
-    result = runner.invoke(app, ["list", "--project-dir", str(tmp_path)])
-    assert result.exit_code == 1
+def test_list_project_outputs(tmp_path):
+    source = tmp_path / "source"
+    roles = source / "roles"
+    roles.mkdir(parents=True)
+    _write_role(roles / "explorer.md", "explorer")
 
-
-def test_list_fails_when_any_installed_role_is_invalid(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "good.md").write_text("---\nname: good\n---\n# Good\n")
-    (roles_dir / "bad.md").write_text("not valid frontmatter\n")
-
-    result = runner.invoke(app, ["list", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 1
-    assert "bad.md" in result.output
-
-
-# -- render command ------------------------------------------------------------
-
-
-def test_render_with_target(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-    result = runner.invoke(
-        app,
-        [
-            "render",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 0
-    assert (tmp_path / ".claude" / "agents" / "explorer.md").is_file()
-
-
-def test_render_cursor_respects_target_config_without_model_map(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-    (tmp_path / "roles.toml").write_text("[targets.cursor]\nenabled = true\n")
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "cursor", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 0, result.output
-    agent_file = tmp_path / ".cursor" / "agents" / "explorer.mdc"
-    assert agent_file.is_file()
-    assert "model:" not in agent_file.read_text()
-
-
-def test_render_windsurf_succeeds_without_model_map(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\n---\n# Explorer\n"
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "windsurf", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 0, result.output
-    agent_file = tmp_path / ".windsurf" / "rules" / "explorer.md"
-    assert agent_file.is_file()
-    assert "model:" not in agent_file.read_text()
-
-
-def test_render_fails_when_any_installed_role_is_invalid(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "good.md").write_text("---\nname: good\n---\n# Good\n")
-    (roles_dir / "bad.md").write_text("not valid frontmatter\n")
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 1
-    assert "bad.md" in result.output
-    assert not (tmp_path / ".claude" / "agents" / "good.md").exists()
-
-
-def test_render_merges_user_and_project_agents(tmp_path, monkeypatch):
     project = tmp_path / "project"
-    project_roles = project / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
     (project / ".claude").mkdir(parents=True)
+    runner.invoke(app, ["add", str(source), "--yes", "--project-dir", str(project)])
 
-    (user_roles / "user-only.md").write_text(
-        "---\nname: user-only\ndescription: User\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# User\n"
-    )
-    (user_roles / "shared.md").write_text(
-        "---\nname: shared\ndescription: User shared\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# User shared\n"
-    )
-    (project_roles / "shared.md").write_text(
-        "---\nname: shared\ndescription: Project shared\nrole: subagent\n"
-        "model:\n  tier: coding\ncapabilities:\n  - read\n---\n# Project shared\n"
-    )
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(project)],
-    )
+    result = runner.invoke(app, ["list", "--project-dir", str(project)])
 
     assert result.exit_code == 0, result.output
-    assert (project / ".claude" / "agents" / "user-only.md").is_file()
-    shared_content = (project / ".claude" / "agents" / "shared.md").read_text()
-    assert "Project shared" in shared_content
-    assert "claude-sonnet-4" in shared_content
+    assert str(source.resolve()) in result.output
+    assert "claude" in result.output
 
 
-def test_render_fails_when_user_scope_contains_invalid_role(tmp_path, monkeypatch):
+def test_list_project_outputs_json(tmp_path):
+    source = tmp_path / "source"
+    roles = source / "roles"
+    roles.mkdir(parents=True)
+    _write_role(roles / "explorer.md", "explorer")
+
     project = tmp_path / "project"
-    project_roles = project / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-    (project_roles / "good.md").write_text("---\nname: good\n---\n# Good\n")
-    (user_roles / "bad.md").write_text("not valid frontmatter\n")
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
+    (project / ".claude").mkdir(parents=True)
+    runner.invoke(app, ["add", str(source), "--yes", "--project-dir", str(project)])
 
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(project)],
-    )
-
-    assert result.exit_code == 1
-    assert "bad.md" in result.output
-
-
-def test_render_fails_when_project_scope_contains_invalid_role_with_valid_user_scope(
-    tmp_path, monkeypatch
-):
-    project = tmp_path / "project"
-    project_roles = project / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-    (project_roles / "bad.md").write_text("not valid frontmatter\n")
-    (user_roles / "good.md").write_text("---\nname: good\n---\n# Good\n")
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(project)],
-    )
-
-    assert result.exit_code == 1
-    assert "bad.md" in result.output
-
-
-def test_render_no_agents(tmp_path, monkeypatch):
-    """Render with no roles in project or user scope must exit 1."""
-    empty_user_roles = tmp_path / "user_roles"
-    empty_user_roles.mkdir()
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", empty_user_roles)
-    result = runner.invoke(
-        app,
-        [
-            "render",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 1
-
-
-def test_render_role_filter_renders_only_matching(tmp_path):
-    """render --role outputs only roles matching (substring of name/id)."""
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    for name in ("explorer", "writer"):
-        (roles_dir / f"{name}.md").write_text(
-            "---\nname: " + name + "\ndescription: x\nrole: subagent\n"
-            "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# x\n"
-        )
-    (tmp_path / ".claude").mkdir()
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--role", "explorer", "--project-dir", str(tmp_path)],
-    )
-    assert result.exit_code == 0, result.output
-    assert (tmp_path / ".claude" / "agents" / "explorer.md").is_file()
-    assert not (tmp_path / ".claude" / "agents" / "writer.md").exists()
-
-
-# -- remove command ------------------------------------------------------------
-
-
-def test_remove_agent(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text("---\nname: explorer\n---\n# E")
-    result = runner.invoke(
-        app,
-        [
-            "remove",
-            "explorer",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 0
-    assert not (roles_dir / "explorer.md").exists()
-
-
-def test_remove_nested_agent_by_canonical_id(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles" / "l2"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "worker.md").write_text("---\nname: worker\n---\n# E")
-
-    result = runner.invoke(
-        app,
-        [
-            "remove",
-            "l2/worker",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 0
-    assert not (roles_dir / "worker.md").exists()
-
-
-def test_remove_global_only_deletes_user_scope(tmp_path, monkeypatch):
-    project_roles = tmp_path / "project" / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-    (project_roles / "shared.md").write_text("---\nname: shared\n---\n# Project")
-    (user_roles / "shared.md").write_text("---\nname: shared\n---\n# User")
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    result = runner.invoke(
-        app,
-        ["remove", "shared", "-g", "--project-dir", str(tmp_path / "project")],
-    )
+    result = runner.invoke(app, ["list", "--json", "--project-dir", str(project)])
 
     assert result.exit_code == 0
-    assert not (user_roles / "shared.md").exists()
-    assert (project_roles / "shared.md").exists()
-
-
-def test_remove_ambiguous_name_requires_canonical_id(tmp_path):
-    left = tmp_path / ".agents" / "roles" / "l2"
-    right = tmp_path / ".agents" / "roles" / "l3"
-    left.mkdir(parents=True)
-    right.mkdir(parents=True)
-    (left / "worker.md").write_text("---\nname: worker\n---\n# L2")
-    (right / "worker.md").write_text("---\nname: worker\n---\n# L3")
-
-    result = runner.invoke(
-        app,
-        [
-            "remove",
-            "worker",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 1
-    assert "Ambiguous agent name" in result.output
-
-
-def test_remove_nonexistent(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    result = runner.invoke(
-        app,
-        [
-            "remove",
-            "nonexistent",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 1
-
-
-# -- update command ------------------------------------------------------------
-
-
-def test_render_uses_roles_toml_targets_without_flag(tmp_path):
-    """render without --target should use targets from roles.toml, not filesystem detection."""
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-
-    # Create filesystem markers for claude AND cursor
-    (tmp_path / ".claude").mkdir()
-    (tmp_path / ".cursor").mkdir()
-
-    # But only configure opencode and claude in roles.toml
-    (tmp_path / "roles.toml").write_text(
-        "[targets.opencode]\n"
-        "enabled = true\n"
-        "[targets.opencode.model_map]\n"
-        'reasoning = "r"\ncoding = "c"\n'
-        "[targets.claude]\n"
-        "enabled = true\n"
-        "[targets.claude.model_map]\n"
-        'reasoning = "opus"\ncoding = "sonnet"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--project-dir", str(tmp_path)],
-    )
-    assert result.exit_code == 0, result.output
-    # Should render opencode and claude (from roles.toml), NOT cursor (filesystem only)
-    assert (tmp_path / ".claude" / "agents" / "explorer.md").is_file()
-    assert (tmp_path / ".opencode" / "agents" / "explorer.md").is_file()
-    assert not (tmp_path / ".cursor" / "agents" / "explorer.mdc").exists()
+    payload = json.loads(result.output)
+    assert payload[0]["source_key"] == str(source.resolve())
+    assert payload[0]["role_ids"] == ["explorer"]
+    assert payload[0]["files"] == [".claude/agents/explorer.md"]
 
 
 def test_update_rejects_local():
@@ -673,10 +188,98 @@ def test_update_rejects_local():
     assert "Cannot update a local source" in result.output
 
 
+def test_update_preserves_previous_role_selection(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    roles = cache / "roles"
+    roles.mkdir(parents=True)
+    _write_role(roles / "explorer.md", "explorer", body="# Explorer v1\n")
+    _write_role(roles / "writer.md", "writer", body="# Writer\n")
+    _write_source_config(cache / "roles.toml")
+
+    project = tmp_path / "project"
+    (project / ".claude").mkdir(parents=True)
+
+    monkeypatch.setattr("role_forge.registry.fetch_source", lambda parsed: cache)
+    monkeypatch.setattr("role_forge.registry.read_head_commit", lambda repo_dir: "abc123def456")
+
+    result = runner.invoke(
+        app,
+        ["add", "org/repo", "--yes", "--role", "explorer", "--project-dir", str(project)],
+    )
+    assert result.exit_code == 0, result.output
+    assert (project / ".claude" / "agents" / "explorer.md").is_file()
+    assert not (project / ".claude" / "agents" / "writer.md").exists()
+
+    _write_role(roles / "explorer.md", "explorer", body="# Explorer v2\n")
+
+    result = runner.invoke(app, ["update", "org/repo", "--yes", "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+    assert "# Explorer v2" in (project / ".claude" / "agents" / "explorer.md").read_text()
+    assert not (project / ".claude" / "agents" / "writer.md").exists()
+
+
+def test_remove_remote_cleans_outputs_and_cache(tmp_path, monkeypatch):
+    cache = _remote_source(tmp_path / "cache")
+    project = tmp_path / "project"
+    (project / ".claude").mkdir(parents=True)
+
+    monkeypatch.setattr("role_forge.registry.fetch_source", lambda parsed: cache)
+    monkeypatch.setattr("role_forge.registry.read_head_commit", lambda repo_dir: "abc123def456")
+
+    result = runner.invoke(app, ["add", "org/repo", "--yes", "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(app, ["remove", "org/repo", "--yes", "--project-dir", str(project)])
+
+    assert result.exit_code == 0, result.output
+    assert not (project / ".claude" / "agents" / "explorer.md").exists()
+    assert not cache.exists()
+
+
+def test_remove_restores_colliding_remaining_source(tmp_path, monkeypatch):
+    cache_a = tmp_path / "cache-a"
+    cache_b = tmp_path / "cache-b"
+    for cache, label in ((cache_a, "A"), (cache_b, "B")):
+        roles = cache / "roles"
+        roles.mkdir(parents=True)
+        _write_role(roles / "explorer.md", "explorer", body=f"# Source {label}\n")
+        _write_source_config(cache / "roles.toml")
+
+    def fake_fetch_source(parsed):
+        return {"org/a": cache_a, "org/b": cache_b}[parsed.cache_key]
+
+    monkeypatch.setattr("role_forge.registry.fetch_source", fake_fetch_source)
+    monkeypatch.setattr("role_forge.registry.read_head_commit", lambda repo_dir: "abc123def456")
+
+    project = tmp_path / "project"
+    (project / ".claude").mkdir(parents=True)
+
+    result = runner.invoke(app, ["add", "org/a", "--yes", "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+    result = runner.invoke(app, ["add", "org/b", "--yes", "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+    assert "# Source B" in (project / ".claude" / "agents" / "explorer.md").read_text()
+
+    result = runner.invoke(app, ["remove", "org/b", "--yes", "--project-dir", str(project)])
+    assert result.exit_code == 0, result.output
+    assert "# Source A" in (project / ".claude" / "agents" / "explorer.md").read_text()
+
+
+def test_remove_unknown_local_source_fails(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    result = runner.invoke(
+        app, ["remove", str(tmp_path / "missing-source"), "--project-dir", str(project)]
+    )
+
+    assert result.exit_code == 1
+    assert "Source not recorded" in result.output
+
+
 def test_add_missing_roles_dir_message_is_actionable(monkeypatch, tmp_path):
     source_root = tmp_path / "cache"
     source_root.mkdir()
-
     monkeypatch.setattr("role_forge.registry.fetch_source", lambda parsed: source_root)
 
     result = runner.invoke(app, ["add", "PFCCLab/precision-agents", "--project-dir", str(tmp_path)])
@@ -687,368 +290,3 @@ def test_add_missing_roles_dir_message_is_actionable(monkeypatch, tmp_path):
         in result.output
     )
     assert "'roles/' directory or [project].roles_dir in roles.toml" in result.output
-
-
-def test_update_global_passes_scope(monkeypatch, tmp_path):
-    calls: list[dict[str, object]] = []
-
-    def fake_add(**kwargs):
-        calls.append(kwargs)
-
-    monkeypatch.setattr("role_forge.cli.add", fake_add)
-
-    result = runner.invoke(
-        app,
-        ["update", "PFCCLab/precision-agents", "-g", "--yes", "--project-dir", str(tmp_path)],
-    )
-
-    assert result.exit_code == 0
-    assert calls == [
-        {
-            "source": "PFCCLab/precision-agents",
-            "yes": True,
-            "global_install": True,
-            "target": None,
-            "no_render": False,
-            "role": None,
-            "project_dir": str(tmp_path),
-        }
-    ]
-
-
-def test_update_prunes_orphaned_agents(monkeypatch, tmp_path):
-    """When update runs and source has removed an agent, the orphaned file is pruned."""
-    cache = tmp_path / "cache"
-    cache.mkdir()
-    roles = cache / "roles"
-    roles.mkdir()
-    (roles / "a.md").write_text("---\nname: a\n---\n# A")
-    (roles / "b.md").write_text("---\nname: b\n---\n# B")
-
-    def fetch_source(parsed):
-        return cache
-
-    monkeypatch.setattr("role_forge.registry.fetch_source", fetch_source)
-    user_roles = tmp_path / ".agents" / "roles"
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-    user_roles.mkdir(parents=True)
-
-    result = runner.invoke(
-        app,
-        ["add", "org/repo", "-g", "--yes", "--no-render", "--project-dir", str(tmp_path)],
-    )
-    assert result.exit_code == 0, result.output
-    assert (user_roles / "a.md").exists()
-    assert (user_roles / "b.md").exists()
-
-    (roles / "b.md").unlink()
-
-    result2 = runner.invoke(
-        app,
-        ["update", "org/repo", "-g", "--yes", "--no-render", "--project-dir", str(tmp_path)],
-    )
-    assert result2.exit_code == 0, result2.output
-    assert (user_roles / "a.md").exists()
-    assert not (user_roles / "b.md").exists()
-
-    result3 = runner.invoke(app, ["list", "-g", "--project-dir", str(tmp_path)])
-    assert result3.exit_code == 0
-    assert "2 role" not in result3.output
-    assert "1 role" in result3.output
-
-
-def test_doctor_reports_unmanaged_files(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "good.md").write_text("---\nname: good\n---\n# Good")
-    (roles_dir / "bad.md").write_text("oops")
-    (roles_dir / "notes.txt").write_text("notes")
-
-    result = runner.invoke(app, ["doctor", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 0
-    assert "bad.md" in result.output
-    assert "notes.txt" in result.output
-
-
-def test_doctor_json_outputs_findings(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "bad.md").write_text("oops")
-
-    result = runner.invoke(app, ["doctor", "--json", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 0
-    payload = json.loads(result.output)
-    assert payload["scope"] == "project"
-    assert payload["issue_count"] == 1
-    assert payload["issues"][0]["relative_path"] == "bad.md"
-
-
-def test_clean_dry_run_keeps_unmanaged_files(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    bad_file = roles_dir / "bad.md"
-    bad_file.write_text("oops")
-
-    result = runner.invoke(app, ["clean", "--dry-run", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 0
-    assert bad_file.exists()
-    assert "Would remove" in result.output
-
-
-def test_clean_yes_removes_only_unmanaged_files(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    good_file = roles_dir / "good.md"
-    bad_file = roles_dir / "bad.md"
-    txt_file = roles_dir / "notes.txt"
-    good_file.write_text("---\nname: good\n---\n# Good")
-    bad_file.write_text("oops")
-    txt_file.write_text("notes")
-
-    result = runner.invoke(app, ["clean", "-y", "--project-dir", str(tmp_path)])
-
-    assert result.exit_code == 0
-    assert good_file.exists()
-    assert not bad_file.exists()
-    assert not txt_file.exists()
-
-
-# -- integration ---------------------------------------------------------------
-
-
-def test_add_uses_roles_toml_config(tmp_path):
-    """add should use model_map from roles.toml (canonical name) when present."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    # Write roles.toml (canonical name) with custom model_map for claude target
-    (project / "roles.toml").write_text(
-        "[targets.claude]\n"
-        "enabled = true\n"
-        "[targets.claude.model_map]\n"
-        'reasoning = "my-custom-reasoning"\n'
-        'coding = "my-custom-coding"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    agent_file = project / ".claude" / "agents" / "explorer.md"
-    assert agent_file.is_file()
-    content = agent_file.read_text()
-    assert "my-custom-reasoning" in content
-
-
-def test_render_uses_roles_toml_config(tmp_path):
-    """render should use model_map from roles.toml (canonical name) when present."""
-    roles_dir = tmp_path / ".agents" / "roles"
-    roles_dir.mkdir(parents=True)
-    (roles_dir / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: coding\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-
-    # Write roles.toml with custom model_map for claude target
-    (tmp_path / "roles.toml").write_text(
-        "[targets.claude]\n"
-        "enabled = true\n"
-        "[targets.claude.model_map]\n"
-        'reasoning = "toml-reasoning"\n'
-        'coding = "toml-coding"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        [
-            "render",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(tmp_path),
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    agent_file = tmp_path / ".claude" / "agents" / "explorer.md"
-    assert agent_file.is_file()
-    content = agent_file.read_text()
-    assert "toml-coding" in content
-
-
-def test_render_namespace_layout_avoids_nested_name_collisions(tmp_path):
-    roles_dir = tmp_path / ".agents" / "roles"
-    (roles_dir / "l2").mkdir(parents=True)
-    (roles_dir / "l3").mkdir(parents=True)
-    (roles_dir / "l2" / "worker.md").write_text(
-        "---\nname: worker\ndescription: L2 worker\n---\n# L2 Worker\n"
-    )
-    (roles_dir / "l3" / "worker.md").write_text(
-        "---\nname: worker\ndescription: L3 worker\n---\n# L3 Worker\n"
-    )
-    (tmp_path / "roles.toml").write_text(
-        '[targets.claude]\n[targets.claude.model_map]\nreasoning = "opus"\ncoding = "sonnet"\n'
-    )
-
-    result = runner.invoke(
-        app,
-        ["render", "--target", "claude", "--project-dir", str(tmp_path)],
-    )
-    assert result.exit_code == 0, result.output
-    assert (tmp_path / ".claude" / "agents" / "l2" / "worker.md").is_file()
-    assert (tmp_path / ".claude" / "agents" / "l3" / "worker.md").is_file()
-
-
-def test_add_opencode_uses_source_repo_model_map(tmp_path):
-    """add with opencode target uses model_map from source repo's roles.toml (no prompt)."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (source / "roles.toml").write_text(
-        '[project]\nroles_dir = "roles"\n\n'
-        "[targets.opencode]\nenabled = true\n\n"
-        "[targets.opencode.model_map]\n"
-        'reasoning = "my-reasoning-model"\ncoding = "my-coding-model"\n'
-    )
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--target",
-            "opencode",
-            "--project-dir",
-            str(project),
-        ],
-        input="p\ny\n",  # scope: project, confirm render
-    )
-    assert result.exit_code == 0, result.output
-    agent_file = project / ".opencode" / "agents" / "explorer.md"
-    assert agent_file.is_file()
-    content = agent_file.read_text()
-    assert "my-reasoning-model" in content
-
-
-def test_add_cursor_uses_source_repo_target_config_without_model_map(tmp_path):
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (source / "roles.toml").write_text(
-        '[project]\nroles_dir = "roles"\n\n[targets.cursor]\nenabled = true\n'
-    )
-    (roles / "explorer.md").write_text("---\nname: explorer\n---\n# Explorer\n")
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    result = runner.invoke(
-        app,
-        ["add", str(source), "--yes", "--project-dir", str(project)],
-    )
-
-    assert result.exit_code == 0, result.output
-    agent_file = project / ".cursor" / "agents" / "explorer.mdc"
-    assert agent_file.is_file()
-    assert "model:" not in agent_file.read_text()
-
-
-def test_full_workflow_add_list_render_remove(tmp_path):
-    """Full workflow: add -> list -> render -> remove."""
-    source = tmp_path / "source"
-    roles = source / "roles"
-    roles.mkdir(parents=True)
-    (roles / "explorer.md").write_text(
-        "---\nname: explorer\ndescription: Explorer\nrole: subagent\n"
-        "model:\n  tier: reasoning\ncapabilities:\n  - read\n---\n# Explorer\n"
-    )
-    (roles / "aligner.md").write_text(
-        "---\nname: aligner\ndescription: Aligner\nrole: subagent\n"
-        "model:\n  tier: coding\ncapabilities:\n  - write\n---\n# Aligner\n"
-    )
-
-    project = tmp_path / "project"
-    project.mkdir()
-
-    # add
-    result = runner.invoke(
-        app,
-        [
-            "add",
-            str(source),
-            "--yes",
-            "--target",
-            "claude",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0
-    assert (project / ".agents" / "roles" / "explorer.md").is_file()
-    assert (project / ".claude" / "agents" / "explorer.md").is_file()
-    assert (project / ".claude" / "agents" / "aligner.md").is_file()
-
-    # list
-    result = runner.invoke(app, ["list", "--project-dir", str(project)])
-    assert result.exit_code == 0
-    assert "explorer" in result.output
-    assert "aligner" in result.output
-    assert "2 role(s) found in project scope" in result.output
-
-    # render (files already exist from add; --yes skips overwrite prompt)
-    result = runner.invoke(
-        app,
-        [
-            "render",
-            "--target",
-            "claude",
-            "--yes",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0
-
-    # remove
-    result = runner.invoke(
-        app,
-        [
-            "remove",
-            "explorer",
-            "--project-dir",
-            str(project),
-        ],
-    )
-    assert result.exit_code == 0
-    assert not (project / ".agents" / "roles" / "explorer.md").exists()
-
-    # list again
-    result = runner.invoke(app, ["list", "--project-dir", str(project)])
-    assert result.exit_code == 0
-    assert "1 role(s) found in project scope" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,11 @@
 """Tests for config.py."""
 
-from pathlib import Path
-
 from role_forge.config import (
     CONFIG_FILENAME,
-    USER_ROLES_DIR,
     find_config,
     load_config,
-    resolve_roles_dir,
+    resolve_output_manifest_path,
+    resolve_source_roles_dir,
 )
 
 
@@ -17,48 +15,30 @@ def test_load_config_from_fixtures(fixtures_dir):
     assert "claude" in config.targets
 
 
-def test_opencode_target_config(fixtures_dir):
+def test_target_config_parsed(fixtures_dir):
     config = load_config(fixtures_dir / "roles.toml")
-    oc = config.targets["opencode"]
-    assert oc.enabled is True
-    assert oc.model_map["reasoning"] == "github-copilot/claude-opus-4.6"
-    assert oc.model_map["coding"] == "github-copilot/gpt-5.2-codex"
-
-
-def test_capability_map_parsed(fixtures_dir):
-    config = load_config(fixtures_dir / "roles.toml")
-    oc = config.targets["opencode"]
-    assert "context7" in oc.capability_map
-    assert oc.capability_map["context7"] == {"context7": True}
-
-
-def test_claude_target_config(fixtures_dir):
-    config = load_config(fixtures_dir / "roles.toml")
-    cl = config.targets["claude"]
-    assert cl.model_map["reasoning"] == "opus"
-    assert cl.model_map["coding"] == "sonnet"
-
-
-# --- find_config tests ---
+    assert config.targets["opencode"].model_map["reasoning"] == "github-copilot/claude-opus-4.6"
+    assert config.targets["claude"].model_map["coding"] == "sonnet"
 
 
 def test_find_config_returns_roles_toml(tmp_path):
-    """find_config returns roles.toml when present."""
     cfg = tmp_path / CONFIG_FILENAME
     cfg.write_text("[project]\n")
-
-    result = find_config(tmp_path)
-    assert result == cfg
+    assert find_config(tmp_path) == cfg
 
 
 def test_find_config_returns_none_when_absent(tmp_path):
-    """find_config returns None if neither config file exists."""
     assert find_config(tmp_path) is None
 
 
-def test_resolve_roles_dir_defaults_when_config_absent(tmp_path):
-    assert resolve_roles_dir(tmp_path) == tmp_path / ".agents" / "roles"
+def test_resolve_source_roles_dir_defaults_when_config_absent(tmp_path):
+    assert resolve_source_roles_dir(tmp_path) == tmp_path / "roles"
 
 
-def test_user_roles_dir_constant_matches_home() -> None:
-    assert Path.home() / ".agents" / "roles" == USER_ROLES_DIR
+def test_resolve_source_roles_dir_uses_roles_toml(tmp_path):
+    (tmp_path / "roles.toml").write_text('[project]\nroles_dir = "my-roles"\n')
+    assert resolve_source_roles_dir(tmp_path) == tmp_path / "my-roles"
+
+
+def test_resolve_output_manifest_path(tmp_path):
+    assert resolve_output_manifest_path(tmp_path) == tmp_path / ".role-forge" / "outputs.json"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,83 +4,46 @@ from pathlib import Path
 
 import pytest
 
-import role_forge.config as config_module
 from role_forge.loader import (
     LoadError,
     _split_frontmatter,
     find_unmanaged_files,
     load_agents,
-    load_agents_in_scope,
-    load_merged_agents,
     parse_agent_file,
 )
 
 
 def test_load_agents_from_fixtures(fixtures_dir):
-    agents = load_agents(fixtures_dir / ".agents" / "roles")
+    agents = load_agents(fixtures_dir / "roles")
     assert len(agents) == 8
-    names = [a.name for a in agents]
-    assert "explorer" in names
-    assert "aligner" in names
-    assert "orchestrator" in names
-    assert "nested-coordinator" in names
-    assert "feature-lead" in names
-    assert "impl-worker" in names
-    assert "qa-worker" in names
-    assert "research-helper" in names
+    assert {agent.name for agent in agents} >= {
+        "explorer",
+        "aligner",
+        "orchestrator",
+        "nested-coordinator",
+    }
 
 
 def test_parse_explorer(fixtures_dir):
-    agent = parse_agent_file(fixtures_dir / ".agents" / "roles" / "explorer.md")
+    agent = parse_agent_file(fixtures_dir / "roles" / "explorer.md")
     assert agent.name == "explorer"
     assert agent.role == "subagent"
     assert agent.model.tier == "reasoning"
     assert agent.model.temperature == 0.05
     assert agent.canonical_id == "explorer"
     assert "repomix-explorer" in agent.skills
-    assert "read" in agent.capabilities
     assert agent.prompt_content.startswith("# Explorer")
 
 
-def test_parse_aligner_no_bash(fixtures_dir):
-    agent = parse_agent_file(fixtures_dir / ".agents" / "roles" / "aligner.md")
-    assert agent.name == "aligner"
-    assert agent.model.tier == "coding"
-    for cap in agent.capabilities:
-        if isinstance(cap, dict):
-            assert "bash" not in cap or not cap.get("bash")
-
-
-def test_capabilities_stored_raw(fixtures_dir):
-    agent = parse_agent_file(fixtures_dir / ".agents" / "roles" / "explorer.md")
-    has_str = any(isinstance(c, str) for c in agent.capabilities)
-    has_dict = any(isinstance(c, dict) for c in agent.capabilities)
-    assert has_str
-    assert has_dict
-
-
 def test_split_frontmatter_valid():
-    text = "---\nname: test\n---\n# Body"
-    fm, body = _split_frontmatter(text)
+    fm, body = _split_frontmatter("---\nname: test\n---\n# Body")
     assert "name: test" in fm
     assert body == "# Body"
 
 
-def test_split_frontmatter_no_opening():
+def test_split_frontmatter_invalid():
     with pytest.raises(LoadError):
         _split_frontmatter("no frontmatter here")
-
-
-def test_split_frontmatter_no_closing():
-    with pytest.raises(LoadError):
-        _split_frontmatter("---\nname: test\n# No closing")
-
-
-def test_split_frontmatter_ignores_body_thematic_break():
-    text = "---\nname: test\n---\n# Body\n\n---\n\nmore body\n"
-    fm, body = _split_frontmatter(text)
-    assert "name: test" in fm
-    assert body == "# Body\n\n---\n\nmore body\n"
 
 
 def test_load_agents_missing_dir():
@@ -89,89 +52,39 @@ def test_load_agents_missing_dir():
 
 
 def test_load_agents_skips_bad_file(tmp_path: Path) -> None:
-    """One malformed file should be skipped while valid agents still load."""
     roles_dir = tmp_path / "roles"
     roles_dir.mkdir()
-
-    # Write a valid agent
     (roles_dir / "good.md").write_text("---\nname: good-agent\ndescription: ok\n---\n# Good")
-    # Write a file without frontmatter — this will raise LoadError
     (roles_dir / "bad.md").write_text("no frontmatter here\n")
 
     agents = load_agents(roles_dir)
-    assert len(agents) == 1
-    assert agents[0].name == "good-agent"
-
-
-def test_load_agents_strict_raises_on_bad_file(tmp_path: Path) -> None:
-    """strict=True should propagate the LoadError from the first bad file."""
-    roles_dir = tmp_path / "roles"
-    roles_dir.mkdir()
-    (roles_dir / "bad.md").write_text("no frontmatter here\n")
-
-    with pytest.raises(LoadError, match=r"bad\.md: File does not start with YAML frontmatter"):
-        load_agents(roles_dir, strict=True)
+    assert [agent.name for agent in agents] == ["good-agent"]
 
 
 def test_load_agents_recursive(tmp_path: Path) -> None:
-    """Agents in sub-directories are discovered and loaded."""
     roles_dir = tmp_path / "roles"
-    roles_dir.mkdir()
-
-    # Top-level agent
-    (roles_dir / "root-agent.md").write_text(
-        "---\nname: root-agent\ndescription: top level\n---\n# Root"
-    )
-    # Sub-directory agent
-    subdir = roles_dir / "team-a"
-    subdir.mkdir()
-    (subdir / "scout.md").write_text(
-        "---\nname: team-a-scout\ndescription: nested scout\n---\n# Scout"
-    )
-    # Deeper nesting
-    deeper = subdir / "deep"
-    deeper.mkdir()
-    (deeper / "worker.md").write_text(
-        "---\nname: deep-worker\ndescription: deeply nested\n---\n# Worker"
+    (roles_dir / "team-a" / "deep").mkdir(parents=True)
+    (roles_dir / "root-agent.md").write_text("---\nname: root-agent\n---\n# Root")
+    (roles_dir / "team-a" / "scout.md").write_text("---\nname: team-a-scout\n---\n# Scout")
+    (roles_dir / "team-a" / "deep" / "worker.md").write_text(
+        "---\nname: deep-worker\n---\n# Worker"
     )
 
     agents = load_agents(roles_dir)
-    names = [a.name for a in agents]
-    assert "root-agent" in names
-    assert "team-a-scout" in names
-    assert "deep-worker" in names
-    assert len(agents) == 3
-    assert {a.canonical_id for a in agents} == {
+    assert {agent.canonical_id for agent in agents} == {
         "root-agent",
         "team-a/scout",
         "team-a/deep/worker",
     }
 
 
-def test_load_agents_recursive_skips_bad_nested(tmp_path: Path) -> None:
-    """A malformed file in a sub-directory is skipped; valid ones still load."""
-    roles_dir = tmp_path / "roles"
-    roles_dir.mkdir()
-
-    (roles_dir / "good.md").write_text("---\nname: good-agent\ndescription: ok\n---\n# Good")
-    subdir = roles_dir / "nested"
-    subdir.mkdir()
-    (subdir / "bad.md").write_text("no frontmatter here\n")
-
-    agents = load_agents(roles_dir)
-    assert len(agents) == 1
-    assert agents[0].name == "good-agent"
-
-
 def test_custom_tier_accepted(tmp_path: Path) -> None:
-    """Any custom tier string should be accepted without validation errors."""
     roles_dir = tmp_path / "roles"
     roles_dir.mkdir()
     (roles_dir / "agent.md").write_text(
         "---\nname: deep-worker\ndescription: test\nmodel:\n  tier: deep\n---\n# Deep Worker\n"
     )
     agents = load_agents(roles_dir)
-    assert len(agents) == 1
     assert agents[0].model.tier == "deep"
 
 
@@ -189,9 +102,8 @@ def test_parse_agent_file_missing_prompt_file_raises(tmp_path: Path) -> None:
 
 def test_parse_hierarchy_metadata(tmp_path: Path) -> None:
     roles_dir = tmp_path / "roles"
-    nested = roles_dir / "l2"
-    nested.mkdir(parents=True)
-    agent_file = nested / "lead.md"
+    agent_file = roles_dir / "l2" / "lead.md"
+    agent_file.parent.mkdir(parents=True)
     agent_file.write_text(
         "---\n"
         "name: lead\n"
@@ -208,74 +120,7 @@ def test_parse_hierarchy_metadata(tmp_path: Path) -> None:
 
     agent = parse_agent_file(agent_file, roles_dir=roles_dir)
     assert agent.canonical_id == "l2/lead"
-    assert agent.relative_path == "l2/lead.md"
-    assert agent.hierarchy.level == "L2"
-    assert agent.hierarchy.role_class == "lead"
-    assert agent.hierarchy.max_delegate_depth == 1
     assert agent.hierarchy.allowed_children == ["l3/worker"]
-
-
-def test_load_nested_fixture_tree_preserves_canonical_ids(fixtures_dir) -> None:
-    agents = load_agents(fixtures_dir / ".agents" / "roles")
-    by_name = {agent.name: agent for agent in agents}
-
-    assert by_name["nested-coordinator"].canonical_id == "nested/nested-coordinator"
-    assert by_name["feature-lead"].canonical_id == "nested/feature-lead"
-    assert by_name["impl-worker"].canonical_id == "nested/workers/impl-worker"
-    assert by_name["qa-worker"].canonical_id == "nested/workers/qa-worker"
-    assert by_name["research-helper"].canonical_id == "nested/support/research-helper"
-
-
-def test_parse_nested_fixture_with_all_capability(fixtures_dir) -> None:
-    agent = parse_agent_file(fixtures_dir / ".agents" / "roles" / "nested" / "feature-lead.md")
-    assert agent.name == "feature-lead"
-    assert "all" in agent.capabilities
-    assert agent.hierarchy.level == "L2"
-
-
-def test_load_agents_in_scope_project_and_user(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    project_roles = tmp_path / "project" / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-    (project_roles / "project.md").write_text("---\nname: project\n---\n# Project")
-    (user_roles / "user.md").write_text("---\nname: user\n---\n# User")
-
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    project_dir, project_agents = load_agents_in_scope(tmp_path / "project", scope="project")
-    user_dir, user_agents = load_agents_in_scope(tmp_path / "project", scope="user")
-
-    assert project_dir == project_roles
-    assert [agent.canonical_id for agent in project_agents] == ["project"]
-    assert user_dir == user_roles
-    assert [agent.canonical_id for agent in user_agents] == ["user"]
-
-
-def test_load_merged_agents_project_overrides_user(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    project = tmp_path / "project"
-    project_roles = project / ".agents" / "roles"
-    user_roles = tmp_path / "user-roles"
-    project_roles.mkdir(parents=True)
-    user_roles.mkdir(parents=True)
-
-    (user_roles / "shared.md").write_text("---\nname: shared\ndescription: user\n---\n# User")
-    (user_roles / "user-only.md").write_text("---\nname: user-only\n---\n# User only")
-    (project_roles / "shared.md").write_text(
-        "---\nname: shared\ndescription: project\n---\n# Project"
-    )
-    (project_roles / "project-only.md").write_text("---\nname: project-only\n---\n# Project only")
-
-    monkeypatch.setattr(config_module, "USER_ROLES_DIR", user_roles)
-
-    agents = load_merged_agents(project)
-
-    assert [agent.canonical_id for agent in agents] == ["project-only", "shared", "user-only"]
-    assert {agent.canonical_id: agent.description for agent in agents}["shared"] == "project"
 
 
 def test_find_unmanaged_files_reports_invalid_markdown_and_other_files(tmp_path: Path) -> None:
@@ -286,7 +131,6 @@ def test_find_unmanaged_files_reports_invalid_markdown_and_other_files(tmp_path:
     (roles_dir / "notes.txt").write_text("oops")
 
     issues = find_unmanaged_files(roles_dir)
-
     assert [(issue.path.name, issue.reason) for issue in issues] == [
         ("bad.md", "File does not start with YAML frontmatter (---)"),
         ("notes.txt", "Non-Markdown file"),

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -63,7 +63,7 @@ def test_cast_all_fixtures(fixtures_dir, opencode_config, snapshot):
     """Cast all fixture agents and verify output count and content."""
     from role_forge.loader import load_agents
 
-    agents = load_agents(fixtures_dir / ".agents" / "roles")
+    agents = load_agents(fixtures_dir / "roles")
     adapter = OpenCodeAdapter()
     outputs = adapter.cast(agents, opencode_config)
     assert len(outputs) == 8


### PR DESCRIPTION
## Summary
- remove the role-store workflow and treat source repos plus `roles.toml` as the only authoritative role semantics
- add a global repo-cache manifest and project-local output ownership manifest for generated files
- simplify CLI flows around `add`, `update`, `list`, and `remove`, including cleanup and rebuild behavior
- update tests and docs to reflect the new source/cache/output model

## Testing
- uv run pytest -q
- just ci